### PR TITLE
[feat] create api and ui for manage preset

### DIFF
--- a/functions/api/[[route]].ts
+++ b/functions/api/[[route]].ts
@@ -5,11 +5,17 @@ import type { Context, Next } from 'hono';
 import type { JwtVariables } from 'hono/jwt';
 import { and, eq, isNull } from 'drizzle-orm';
 import { getDb } from '../../db';
-import { users, classrooms, students } from '../../db/schema';
+import { users, classrooms, students, subjects, lessonTypes, timeSlots } from '../../db/schema';
 import {
   validateCreateClassroomInput,
+  validateCreateLessonTypeInput,
   validateCreateStudentInput,
+  validateCreateSubjectInput,
+  validateCreateTimeSlotInput,
   validateCreateUserInput,
+  validatePatchLessonTypeInput,
+  validatePatchSubjectInput,
+  validatePatchTimeSlotInput,
 } from './validators';
 
 type Bindings = Env & {
@@ -93,6 +99,11 @@ function isD1UsersEmailUniqueViolation(error: unknown): boolean {
     lower.includes('unique constraint failed') ||
     lower.includes('unique constraint')
   );
+}
+
+function isD1ForeignKeyViolation(error: unknown): boolean {
+  const text = collectErrorTextParts(error).join(' ').toLowerCase();
+  return text.includes('foreign key');
 }
 
 export const app = new Hono<{ Bindings: Bindings; Variables: AppVariables }>().basePath('/api');
@@ -238,33 +249,45 @@ const requireManagerOrAbove = async (c: Context<{Bindings: Bindings; Variables: 
   await next();
 };
 
-/** 対象 classroomId へのアクセス: 管理者は全教室、教室長・一般講師は自教室のみ（manager 専用ルートでは requireManagerOrAbove と併用） */
-const requireClassroomScope = (
-  resolveClassroomId: (c: Context<{ Bindings: Bindings; Variables: AppVariables }>) => string | null,
-) =>
-  async (c: Context<{ Bindings: Bindings; Variables: AppVariables }>, next: Next) => {
-    const currentUser = c.var.currentUser;
+type ApiContext = Context<{ Bindings: Bindings; Variables: AppVariables }>;
 
-    if (!currentUser) {
-      return c.json({ message: 'user not loaded' }, 500);
-    }
+/**
+ * 対象 classroomId へのアクセス可否（requireClassroomScope と同一ルール）。
+ * 解決済みの classroomId を渡す PATCH/DELETE 等でも使う。
+ */
+function denyUnlessClassroomScope(c: ApiContext, targetClassroomId: string | null | undefined): Response | null {
+  const currentUser = c.var.currentUser;
+  if (!currentUser) {
+    return c.json({ message: 'user not loaded' }, 500);
+  }
+  const id = typeof targetClassroomId === 'string' ? targetClassroomId.trim() : '';
+  if (!id) {
+    return c.json({ message: 'classroom id is required' }, 400);
+  }
+  if (currentUser.role === 'admin') {
+    return null;
+  }
+  if (!currentUser.classroomId || currentUser.classroomId !== id) {
+    return c.json({ message: 'forbidden' }, 403);
+  }
+  return null;
+}
 
+/** 対象 classroomId へのアクセス: 管理者は全教室、教室長は自教室のみ（requireManagerOrAbove と併用） */
+const requireClassroomScope = (resolveClassroomId: (c: ApiContext) => string | null) =>
+  async (c: ApiContext, next: Next) => {
     const targetClassroomId = resolveClassroomId(c);
-    if (!targetClassroomId) {
-      return c.json({ message: 'classroom id is required' }, 400);
+    const denied = denyUnlessClassroomScope(c, targetClassroomId);
+    if (denied) {
+      return denied;
     }
-
-    if (currentUser.role === 'admin') {
-      await next();
-      return;
-    }
-
-    if (!currentUser.classroomId || currentUser.classroomId !== targetClassroomId) {
-      return c.json({ message: 'forbidden' }, 403);
-    }
-
     await next();
   };
+
+function hmToMinutes(hm: string): number {
+  const [h, m] = hm.split(':').map(Number);
+  return h * 60 + m;
+}
 
 app.post('/classrooms', auth, loadUser, requireAdmin, async (c) => {
   const body = await c.req.json<unknown>().catch(() => null);
@@ -328,10 +351,24 @@ app.delete('/classrooms/:id', auth, loadUser, requireAdmin, async(c) =>{
   }
 
   let txResult:
-    | { notFound: true; updatedUserIds: string[]; updatedStudentIds: string[] }
-    | { notFound: false; updatedUserIds: string[]; updatedStudentIds: string[] };
+    | {
+        notFound: true;
+        updatedUserIds: string[];
+        updatedStudentIds: string[];
+        updatedSubjectIds: string[];
+        updatedLessonTypeIds: string[];
+        updatedTimeSlotIds: string[];
+      }
+    | {
+        notFound: false;
+        updatedUserIds: string[];
+        updatedStudentIds: string[];
+        updatedSubjectIds: string[];
+        updatedLessonTypeIds: string[];
+        updatedTimeSlotIds: string[];
+      };
   try {
-    // Serialize classroom soft-delete + user/student soft-deletes. `immediate` takes a write lock early.
+    // Serialize classroom soft-delete + user/student/preset soft-deletes. `immediate` takes a write lock early.
     // Members are selected only after the classroom row is marked deleted so concurrent creates
     // that re-check `classrooms.deleted_at` cannot commit into an "open" classroom.
     txResult = await db.transaction(
@@ -346,6 +383,9 @@ app.delete('/classrooms/:id', auth, loadUser, requireAdmin, async(c) =>{
             notFound: true as const,
             updatedUserIds: [] as string[],
             updatedStudentIds: [] as string[],
+            updatedSubjectIds: [] as string[],
+            updatedLessonTypeIds: [] as string[],
+            updatedTimeSlotIds: [] as string[],
           };
         }
 
@@ -383,7 +423,62 @@ app.delete('/classrooms/:id', auth, loadUser, requireAdmin, async(c) =>{
           }
         }
 
-        return { notFound: false as const, updatedUserIds, updatedStudentIds };
+        const classroomSubjects = await tx
+          .select({ id: subjects.id })
+          .from(subjects)
+          .where(and(eq(subjects.classroomId, id), isNull(subjects.deletedAt)));
+
+        const updatedSubjectIds: string[] = [];
+        for (const row of classroomSubjects) {
+          const r = await tx
+            .update(subjects)
+            .set({ deletedAt })
+            .where(and(eq(subjects.id, row.id), isNull(subjects.deletedAt)));
+          if (r.meta.changes > 0) {
+            updatedSubjectIds.push(row.id);
+          }
+        }
+
+        const classroomLessonTypes = await tx
+          .select({ id: lessonTypes.id })
+          .from(lessonTypes)
+          .where(and(eq(lessonTypes.classroomId, id), isNull(lessonTypes.deletedAt)));
+
+        const updatedLessonTypeIds: string[] = [];
+        for (const row of classroomLessonTypes) {
+          const r = await tx
+            .update(lessonTypes)
+            .set({ deletedAt })
+            .where(and(eq(lessonTypes.id, row.id), isNull(lessonTypes.deletedAt)));
+          if (r.meta.changes > 0) {
+            updatedLessonTypeIds.push(row.id);
+          }
+        }
+
+        const classroomTimeSlots = await tx
+          .select({ id: timeSlots.id })
+          .from(timeSlots)
+          .where(and(eq(timeSlots.classroomId, id), isNull(timeSlots.deletedAt)));
+
+        const updatedTimeSlotIds: string[] = [];
+        for (const row of classroomTimeSlots) {
+          const r = await tx
+            .update(timeSlots)
+            .set({ deletedAt })
+            .where(and(eq(timeSlots.id, row.id), isNull(timeSlots.deletedAt)));
+          if (r.meta.changes > 0) {
+            updatedTimeSlotIds.push(row.id);
+          }
+        }
+
+        return {
+          notFound: false as const,
+          updatedUserIds,
+          updatedStudentIds,
+          updatedSubjectIds,
+          updatedLessonTypeIds,
+          updatedTimeSlotIds,
+        };
       },
       { behavior: 'immediate' },
     );
@@ -395,14 +490,41 @@ app.delete('/classrooms/:id', auth, loadUser, requireAdmin, async(c) =>{
     return c.json({ message: 'classroom not found' }, 404);
   }
 
-  const { updatedUserIds, updatedStudentIds } = txResult;
+  const {
+    updatedUserIds,
+    updatedStudentIds,
+    updatedSubjectIds,
+    updatedLessonTypeIds,
+    updatedTimeSlotIds,
+  } = txResult;
 
-  const rollbackStudentSoftDeletes = async () => {
+  const rollbackClassroomChildSoftDeletes = async () => {
     for (const studentId of updatedStudentIds) {
       await db
         .update(students)
         .set({ deletedAt: null })
         .where(eq(students.id, studentId))
+        .catch(() => undefined);
+    }
+    for (const presetId of updatedSubjectIds) {
+      await db
+        .update(subjects)
+        .set({ deletedAt: null })
+        .where(eq(subjects.id, presetId))
+        .catch(() => undefined);
+    }
+    for (const presetId of updatedLessonTypeIds) {
+      await db
+        .update(lessonTypes)
+        .set({ deletedAt: null })
+        .where(eq(lessonTypes.id, presetId))
+        .catch(() => undefined);
+    }
+    for (const presetId of updatedTimeSlotIds) {
+      await db
+        .update(timeSlots)
+        .set({ deletedAt: null })
+        .where(eq(timeSlots.id, presetId))
         .catch(() => undefined);
     }
   };
@@ -415,7 +537,7 @@ app.delete('/classrooms/:id', auth, loadUser, requireAdmin, async(c) =>{
       for (const userId of updatedUserIds) {
         await db.update(users).set({ deletedAt: null }).where(eq(users.id, userId)).catch(() => undefined);
       }
-      await rollbackStudentSoftDeletes();
+      await rollbackClassroomChildSoftDeletes();
       return c.json({ message: 'failed to delete classroom' }, 400);
     }
   }
@@ -437,7 +559,7 @@ app.delete('/classrooms/:id', auth, loadUser, requireAdmin, async(c) =>{
         await db.update(users).set({ deletedAt: null }).where(eq(users.id, userId)).catch(() => undefined);
       }
     }
-    await rollbackStudentSoftDeletes();
+    await rollbackClassroomChildSoftDeletes();
     return c.json({ message: 'failed to delete classroom' }, 400);
   }
 
@@ -676,43 +798,31 @@ app.post('/students', auth, loadUser, requireManagerOrAbove, async (c) => {
   const db = getDb(c.env);
   const id = crypto.randomUUID();
 
-  type CreateStudentTxResult =
-    | { ok: true }
-    | { ok: false; reason: 'classroom_not_found' };
+  const [activeClassroom] = await db
+    .select({ id: classrooms.id })
+    .from(classrooms)
+    .where(and(eq(classrooms.id, input.classroomId), isNull(classrooms.deletedAt)))
+    .limit(1);
 
-  let txResult: CreateStudentTxResult;
-  try {
-    txResult = await db.transaction(
-      async (tx) => {
-        const [activeClassroom] = await tx
-          .select({ id: classrooms.id })
-          .from(classrooms)
-          .where(and(eq(classrooms.id, input.classroomId), isNull(classrooms.deletedAt)))
-          .limit(1);
-
-        if (!activeClassroom) {
-          return { ok: false as const, reason: 'classroom_not_found' as const };
-        }
-
-        await tx.insert(students).values({
-          id,
-          name: input.name,
-          email: input.email,
-          birthYear: input.birthYear,
-          classroomId: input.classroomId,
-          deletedAt: null,
-        });
-
-        return { ok: true as const };
-      },
-      { behavior: 'immediate' },
-    );
-  } catch {
-    return c.json({ message: 'failed to create student' }, 400);
+  if (!activeClassroom) {
+    return c.json({ message: 'classroom not found' }, 404);
   }
 
-  if (!txResult.ok) {
-    return c.json({ message: 'classroom not found' }, 404);
+  try {
+    await db.insert(students).values({
+      id,
+      name: input.name,
+      email: input.email,
+      birthYear: input.birthYear,
+      classroomId: input.classroomId,
+      deletedAt: null,
+    });
+  } catch (err) {
+    if (isD1ForeignKeyViolation(err)) {
+      return c.json({ message: 'classroom not found' }, 404);
+    }
+    const detail = collectErrorTextParts(err).join(' ') || (err instanceof Error ? err.message : String(err));
+    return c.json({ message: 'failed to create student', detail }, 500);
   }
 
   return c.json(
@@ -783,6 +893,394 @@ app.get('/students/:classroomId', auth, loadUser, requireClassroomScope((c) => c
     .from(students)
     .where(and(eq(students.classroomId, classroomId), isNull(students.deletedAt)));
   return c.json(rows, 200);
+});
+
+app.get(
+  '/classrooms/:classroomId/subjects',
+  auth,
+  loadUser,
+  requireManagerOrAbove,
+  requireClassroomScope((c) => c.req.param('classroomId') ?? null),
+  async (c) => {
+    const classroomId = c.req.param('classroomId');
+    if (!classroomId) {
+      return c.json({ message: 'classroom id is required' }, 400);
+    }
+    const db = getDb(c.env);
+    const rows = await db
+      .select({ id: subjects.id, name: subjects.name })
+      .from(subjects)
+      .where(and(eq(subjects.classroomId, classroomId), isNull(subjects.deletedAt)));
+    return c.json(rows, 200);
+  },
+);
+
+app.get(
+  '/classrooms/:classroomId/lesson-types',
+  auth,
+  loadUser,
+  requireManagerOrAbove,
+  requireClassroomScope((c) => c.req.param('classroomId') ?? null),
+  async (c) => {
+    const classroomId = c.req.param('classroomId');
+    if (!classroomId) {
+      return c.json({ message: 'classroom id is required' }, 400);
+    }
+    const db = getDb(c.env);
+    const rows = await db
+      .select({ id: lessonTypes.id, name: lessonTypes.name })
+      .from(lessonTypes)
+      .where(and(eq(lessonTypes.classroomId, classroomId), isNull(lessonTypes.deletedAt)));
+    return c.json(rows, 200);
+  },
+);
+
+app.get(
+  '/classrooms/:classroomId/time-slots',
+  auth,
+  loadUser,
+  requireManagerOrAbove,
+  requireClassroomScope((c) => c.req.param('classroomId') ?? null),
+  async (c) => {
+    const classroomId = c.req.param('classroomId');
+    if (!classroomId) {
+      return c.json({ message: 'classroom id is required' }, 400);
+    }
+    const db = getDb(c.env);
+    const rows = await db
+      .select({
+        id: timeSlots.id,
+        startTime: timeSlots.startTime,
+        endTime: timeSlots.endTime,
+      })
+      .from(timeSlots)
+      .where(and(eq(timeSlots.classroomId, classroomId), isNull(timeSlots.deletedAt)));
+    return c.json(rows, 200);
+  },
+);
+
+app.post('/subjects', auth, loadUser, requireManagerOrAbove, async (c) => {
+  const actor = c.var.currentUser;
+  const body = await c.req.json<unknown>().catch(() => null);
+  const { input, error } = validateCreateSubjectInput(body);
+  if (!input) {
+    return c.json({ message: error ?? 'invalid request' }, 400);
+  }
+  if (actor.role === 'manager' && actor.classroomId !== input.classroomId) {
+    return c.json({ message: 'forbidden' }, 403);
+  }
+  const db = getDb(c.env);
+  const newId = crypto.randomUUID();
+  const [activeClassroom] = await db
+    .select({ id: classrooms.id })
+    .from(classrooms)
+    .where(and(eq(classrooms.id, input.classroomId), isNull(classrooms.deletedAt)))
+    .limit(1);
+  if (!activeClassroom) {
+    return c.json({ message: 'classroom not found' }, 404);
+  }
+  try {
+    await db.insert(subjects).values({
+      id: newId,
+      name: input.name,
+      classroomId: input.classroomId,
+      deletedAt: null,
+    });
+  } catch (err) {
+    if (isD1ForeignKeyViolation(err)) {
+      return c.json({ message: 'classroom not found' }, 404);
+    }
+    const detail = collectErrorTextParts(err).join(' ') || (err instanceof Error ? err.message : String(err));
+    return c.json({ message: 'failed to create subject', detail }, 500);
+  }
+  return c.json({ id: newId, name: input.name, classroomId: input.classroomId }, 201);
+});
+
+app.post('/lesson-types', auth, loadUser, requireManagerOrAbove, async (c) => {
+  const actor = c.var.currentUser;
+  const body = await c.req.json<unknown>().catch(() => null);
+  const { input, error } = validateCreateLessonTypeInput(body);
+  if (!input) {
+    return c.json({ message: error ?? 'invalid request' }, 400);
+  }
+  if (actor.role === 'manager' && actor.classroomId !== input.classroomId) {
+    return c.json({ message: 'forbidden' }, 403);
+  }
+  const db = getDb(c.env);
+  const newId = crypto.randomUUID();
+  const [activeClassroom] = await db
+    .select({ id: classrooms.id })
+    .from(classrooms)
+    .where(and(eq(classrooms.id, input.classroomId), isNull(classrooms.deletedAt)))
+    .limit(1);
+  if (!activeClassroom) {
+    return c.json({ message: 'classroom not found' }, 404);
+  }
+  try {
+    await db.insert(lessonTypes).values({
+      id: newId,
+      name: input.name,
+      classroomId: input.classroomId,
+      deletedAt: null,
+    });
+  } catch (err) {
+    if (isD1ForeignKeyViolation(err)) {
+      return c.json({ message: 'classroom not found' }, 404);
+    }
+    const detail = collectErrorTextParts(err).join(' ') || (err instanceof Error ? err.message : String(err));
+    return c.json({ message: 'failed to create lesson type', detail }, 500);
+  }
+  return c.json({ id: newId, name: input.name, classroomId: input.classroomId }, 201);
+});
+
+app.post('/time-slots', auth, loadUser, requireManagerOrAbove, async (c) => {
+  const actor = c.var.currentUser;
+  const body = await c.req.json<unknown>().catch(() => null);
+  const { input, error } = validateCreateTimeSlotInput(body);
+  if (!input) {
+    return c.json({ message: error ?? 'invalid request' }, 400);
+  }
+  if (actor.role === 'manager' && actor.classroomId !== input.classroomId) {
+    return c.json({ message: 'forbidden' }, 403);
+  }
+  const db = getDb(c.env);
+  const newId = crypto.randomUUID();
+  const [activeClassroom] = await db
+    .select({ id: classrooms.id })
+    .from(classrooms)
+    .where(and(eq(classrooms.id, input.classroomId), isNull(classrooms.deletedAt)))
+    .limit(1);
+  if (!activeClassroom) {
+    return c.json({ message: 'classroom not found' }, 404);
+  }
+  try {
+    await db.insert(timeSlots).values({
+      id: newId,
+      classroomId: input.classroomId,
+      startTime: input.startTime,
+      endTime: input.endTime,
+      deletedAt: null,
+    });
+  } catch (err) {
+    if (isD1ForeignKeyViolation(err)) {
+      return c.json({ message: 'classroom not found' }, 404);
+    }
+    const detail = collectErrorTextParts(err).join(' ') || (err instanceof Error ? err.message : String(err));
+    return c.json({ message: 'failed to create time slot', detail }, 500);
+  }
+  return c.json(
+    {
+      id: newId,
+      classroomId: input.classroomId,
+      startTime: input.startTime,
+      endTime: input.endTime,
+    },
+    201,
+  );
+});
+
+app.patch('/subjects/:id', auth, loadUser, requireManagerOrAbove, async (c) => {
+  const targetId = c.req.param('id');
+  if (!targetId) {
+    return c.json({ message: 'id is required' }, 400);
+  }
+  const body = await c.req.json<unknown>().catch(() => null);
+  const { input, error } = validatePatchSubjectInput(body);
+  if (!input) {
+    return c.json({ message: error ?? 'invalid request' }, 400);
+  }
+  const db = getDb(c.env);
+  const [row] = await db
+    .select({ id: subjects.id, classroomId: subjects.classroomId })
+    .from(subjects)
+    .where(and(eq(subjects.id, targetId), isNull(subjects.deletedAt)))
+    .limit(1);
+  if (!row) {
+    return c.json({ message: 'subject not found' }, 404);
+  }
+  const scopeDenied = denyUnlessClassroomScope(c, row.classroomId);
+  if (scopeDenied) {
+    return scopeDenied;
+  }
+  const result = await db
+    .update(subjects)
+    .set({ name: input.name })
+    .where(and(eq(subjects.id, targetId), isNull(subjects.deletedAt)));
+  if (result.meta.changes === 0) {
+    return c.json({ message: 'subject not found' }, 404);
+  }
+  return c.json({ id: targetId, name: input.name, classroomId: row.classroomId }, 200);
+});
+
+app.patch('/lesson-types/:id', auth, loadUser, requireManagerOrAbove, async (c) => {
+  const targetId = c.req.param('id');
+  if (!targetId) {
+    return c.json({ message: 'id is required' }, 400);
+  }
+  const body = await c.req.json<unknown>().catch(() => null);
+  const { input, error } = validatePatchLessonTypeInput(body);
+  if (!input) {
+    return c.json({ message: error ?? 'invalid request' }, 400);
+  }
+  const db = getDb(c.env);
+  const [row] = await db
+    .select({ id: lessonTypes.id, classroomId: lessonTypes.classroomId })
+    .from(lessonTypes)
+    .where(and(eq(lessonTypes.id, targetId), isNull(lessonTypes.deletedAt)))
+    .limit(1);
+  if (!row) {
+    return c.json({ message: 'lesson type not found' }, 404);
+  }
+  const scopeDenied = denyUnlessClassroomScope(c, row.classroomId);
+  if (scopeDenied) {
+    return scopeDenied;
+  }
+  const result = await db
+    .update(lessonTypes)
+    .set({ name: input.name })
+    .where(and(eq(lessonTypes.id, targetId), isNull(lessonTypes.deletedAt)));
+  if (result.meta.changes === 0) {
+    return c.json({ message: 'lesson type not found' }, 404);
+  }
+  return c.json({ id: targetId, name: input.name, classroomId: row.classroomId }, 200);
+});
+
+app.patch('/time-slots/:id', auth, loadUser, requireManagerOrAbove, async (c) => {
+  const targetId = c.req.param('id');
+  if (!targetId) {
+    return c.json({ message: 'id is required' }, 400);
+  }
+  const body = await c.req.json<unknown>().catch(() => null);
+  const { input, error } = validatePatchTimeSlotInput(body);
+  if (!input) {
+    return c.json({ message: error ?? 'invalid request' }, 400);
+  }
+  const db = getDb(c.env);
+  const [row] = await db
+    .select({
+      id: timeSlots.id,
+      classroomId: timeSlots.classroomId,
+      startTime: timeSlots.startTime,
+      endTime: timeSlots.endTime,
+    })
+    .from(timeSlots)
+    .where(and(eq(timeSlots.id, targetId), isNull(timeSlots.deletedAt)))
+    .limit(1);
+  if (!row) {
+    return c.json({ message: 'time slot not found' }, 404);
+  }
+  const scopeDenied = denyUnlessClassroomScope(c, row.classroomId);
+  if (scopeDenied) {
+    return scopeDenied;
+  }
+  const nextStart = input.startTime ?? row.startTime;
+  const nextEnd = input.endTime ?? row.endTime;
+  if (hmToMinutes(nextStart) >= hmToMinutes(nextEnd)) {
+    return c.json({ message: 'end time must be after start time' }, 400);
+  }
+  const result = await db
+    .update(timeSlots)
+    .set({ startTime: nextStart, endTime: nextEnd })
+    .where(and(eq(timeSlots.id, targetId), isNull(timeSlots.deletedAt)));
+  if (result.meta.changes === 0) {
+    return c.json({ message: 'time slot not found' }, 404);
+  }
+  return c.json(
+    {
+      id: targetId,
+      classroomId: row.classroomId,
+      startTime: nextStart,
+      endTime: nextEnd,
+    },
+    200,
+  );
+});
+
+app.delete('/subjects/:id', auth, loadUser, requireManagerOrAbove, async (c) => {
+  const targetId = c.req.param('id');
+  if (!targetId) {
+    return c.json({ message: 'id is required' }, 400);
+  }
+  const db = getDb(c.env);
+  const [row] = await db
+    .select({ id: subjects.id, classroomId: subjects.classroomId })
+    .from(subjects)
+    .where(and(eq(subjects.id, targetId), isNull(subjects.deletedAt)))
+    .limit(1);
+  if (!row) {
+    return c.json({ message: 'subject not found' }, 404);
+  }
+  const scopeDenied = denyUnlessClassroomScope(c, row.classroomId);
+  if (scopeDenied) {
+    return scopeDenied;
+  }
+  const deletedAt = new Date();
+  const result = await db
+    .update(subjects)
+    .set({ deletedAt })
+    .where(and(eq(subjects.id, targetId), isNull(subjects.deletedAt)));
+  if (result.meta.changes === 0) {
+    return c.json({ message: 'subject not found' }, 404);
+  }
+  return c.json({ success: true }, 200);
+});
+
+app.delete('/lesson-types/:id', auth, loadUser, requireManagerOrAbove, async (c) => {
+  const targetId = c.req.param('id');
+  if (!targetId) {
+    return c.json({ message: 'id is required' }, 400);
+  }
+  const db = getDb(c.env);
+  const [row] = await db
+    .select({ id: lessonTypes.id, classroomId: lessonTypes.classroomId })
+    .from(lessonTypes)
+    .where(and(eq(lessonTypes.id, targetId), isNull(lessonTypes.deletedAt)))
+    .limit(1);
+  if (!row) {
+    return c.json({ message: 'lesson type not found' }, 404);
+  }
+  const scopeDenied = denyUnlessClassroomScope(c, row.classroomId);
+  if (scopeDenied) {
+    return scopeDenied;
+  }
+  const deletedAt = new Date();
+  const result = await db
+    .update(lessonTypes)
+    .set({ deletedAt })
+    .where(and(eq(lessonTypes.id, targetId), isNull(lessonTypes.deletedAt)));
+  if (result.meta.changes === 0) {
+    return c.json({ message: 'lesson type not found' }, 404);
+  }
+  return c.json({ success: true }, 200);
+});
+
+app.delete('/time-slots/:id', auth, loadUser, requireManagerOrAbove, async (c) => {
+  const targetId = c.req.param('id');
+  if (!targetId) {
+    return c.json({ message: 'id is required' }, 400);
+  }
+  const db = getDb(c.env);
+  const [row] = await db
+    .select({ id: timeSlots.id, classroomId: timeSlots.classroomId })
+    .from(timeSlots)
+    .where(and(eq(timeSlots.id, targetId), isNull(timeSlots.deletedAt)))
+    .limit(1);
+  if (!row) {
+    return c.json({ message: 'time slot not found' }, 404);
+  }
+  const scopeDenied = denyUnlessClassroomScope(c, row.classroomId);
+  if (scopeDenied) {
+    return scopeDenied;
+  }
+  const deletedAt = new Date();
+  const result = await db
+    .update(timeSlots)
+    .set({ deletedAt })
+    .where(and(eq(timeSlots.id, targetId), isNull(timeSlots.deletedAt)));
+  if (result.meta.changes === 0) {
+    return c.json({ message: 'time slot not found' }, 404);
+  }
+  return c.json({ success: true }, 200);
 });
 
 app.get('/me', auth, async (c) => {

--- a/functions/api/[[route]].ts
+++ b/functions/api/[[route]].ts
@@ -991,21 +991,31 @@ app.post('/subjects', auth, loadUser, requireManagerOrAbove, async (c) => {
   }
   const db = getDb(c.env);
   const newId = crypto.randomUUID();
-  const [activeClassroom] = await db
-    .select({ id: classrooms.id })
-    .from(classrooms)
-    .where(and(eq(classrooms.id, input.classroomId), isNull(classrooms.deletedAt)))
-    .limit(1);
-  if (!activeClassroom) {
-    return c.json({ message: 'classroom not found' }, 404);
-  }
+
+  type CreateSubjectTxResult = { ok: true } | { ok: false; reason: 'classroom_not_found' };
+
+  let txResult: CreateSubjectTxResult;
   try {
-    await db.insert(subjects).values({
-      id: newId,
-      name: input.name,
-      classroomId: input.classroomId,
-      deletedAt: null,
-    });
+    txResult = await db.transaction(
+      async (tx) => {
+        const [activeClassroom] = await tx
+          .select({ id: classrooms.id })
+          .from(classrooms)
+          .where(and(eq(classrooms.id, input.classroomId), isNull(classrooms.deletedAt)))
+          .limit(1);
+        if (!activeClassroom) {
+          return { ok: false as const, reason: 'classroom_not_found' as const };
+        }
+        await tx.insert(subjects).values({
+          id: newId,
+          name: input.name,
+          classroomId: input.classroomId,
+          deletedAt: null,
+        });
+        return { ok: true as const };
+      },
+      { behavior: 'immediate' },
+    );
   } catch (err) {
     logApiError('POST /subjects', err);
     if (isD1ForeignKeyViolation(err)) {
@@ -1013,6 +1023,11 @@ app.post('/subjects', auth, loadUser, requireManagerOrAbove, async (c) => {
     }
     return c.json({ message: 'failed to create subject' }, 500);
   }
+
+  if (!txResult.ok) {
+    return c.json({ message: 'classroom not found' }, 404);
+  }
+
   return c.json({ id: newId, name: input.name, classroomId: input.classroomId }, 201);
 });
 
@@ -1028,21 +1043,31 @@ app.post('/lesson-types', auth, loadUser, requireManagerOrAbove, async (c) => {
   }
   const db = getDb(c.env);
   const newId = crypto.randomUUID();
-  const [activeClassroom] = await db
-    .select({ id: classrooms.id })
-    .from(classrooms)
-    .where(and(eq(classrooms.id, input.classroomId), isNull(classrooms.deletedAt)))
-    .limit(1);
-  if (!activeClassroom) {
-    return c.json({ message: 'classroom not found' }, 404);
-  }
+
+  type CreateLessonTypeTxResult = { ok: true } | { ok: false; reason: 'classroom_not_found' };
+
+  let txResult: CreateLessonTypeTxResult;
   try {
-    await db.insert(lessonTypes).values({
-      id: newId,
-      name: input.name,
-      classroomId: input.classroomId,
-      deletedAt: null,
-    });
+    txResult = await db.transaction(
+      async (tx) => {
+        const [activeClassroom] = await tx
+          .select({ id: classrooms.id })
+          .from(classrooms)
+          .where(and(eq(classrooms.id, input.classroomId), isNull(classrooms.deletedAt)))
+          .limit(1);
+        if (!activeClassroom) {
+          return { ok: false as const, reason: 'classroom_not_found' as const };
+        }
+        await tx.insert(lessonTypes).values({
+          id: newId,
+          name: input.name,
+          classroomId: input.classroomId,
+          deletedAt: null,
+        });
+        return { ok: true as const };
+      },
+      { behavior: 'immediate' },
+    );
   } catch (err) {
     logApiError('POST /lesson-types', err);
     if (isD1ForeignKeyViolation(err)) {
@@ -1050,6 +1075,11 @@ app.post('/lesson-types', auth, loadUser, requireManagerOrAbove, async (c) => {
     }
     return c.json({ message: 'failed to create lesson type' }, 500);
   }
+
+  if (!txResult.ok) {
+    return c.json({ message: 'classroom not found' }, 404);
+  }
+
   return c.json({ id: newId, name: input.name, classroomId: input.classroomId }, 201);
 });
 
@@ -1065,22 +1095,32 @@ app.post('/time-slots', auth, loadUser, requireManagerOrAbove, async (c) => {
   }
   const db = getDb(c.env);
   const newId = crypto.randomUUID();
-  const [activeClassroom] = await db
-    .select({ id: classrooms.id })
-    .from(classrooms)
-    .where(and(eq(classrooms.id, input.classroomId), isNull(classrooms.deletedAt)))
-    .limit(1);
-  if (!activeClassroom) {
-    return c.json({ message: 'classroom not found' }, 404);
-  }
+
+  type CreateTimeSlotTxResult = { ok: true } | { ok: false; reason: 'classroom_not_found' };
+
+  let txResult: CreateTimeSlotTxResult;
   try {
-    await db.insert(timeSlots).values({
-      id: newId,
-      classroomId: input.classroomId,
-      startTime: input.startTime,
-      endTime: input.endTime,
-      deletedAt: null,
-    });
+    txResult = await db.transaction(
+      async (tx) => {
+        const [activeClassroom] = await tx
+          .select({ id: classrooms.id })
+          .from(classrooms)
+          .where(and(eq(classrooms.id, input.classroomId), isNull(classrooms.deletedAt)))
+          .limit(1);
+        if (!activeClassroom) {
+          return { ok: false as const, reason: 'classroom_not_found' as const };
+        }
+        await tx.insert(timeSlots).values({
+          id: newId,
+          classroomId: input.classroomId,
+          startTime: input.startTime,
+          endTime: input.endTime,
+          deletedAt: null,
+        });
+        return { ok: true as const };
+      },
+      { behavior: 'immediate' },
+    );
   } catch (err) {
     logApiError('POST /time-slots', err);
     if (isD1ForeignKeyViolation(err)) {
@@ -1088,6 +1128,11 @@ app.post('/time-slots', auth, loadUser, requireManagerOrAbove, async (c) => {
     }
     return c.json({ message: 'failed to create time slot' }, 500);
   }
+
+  if (!txResult.ok) {
+    return c.json({ message: 'classroom not found' }, 404);
+  }
+
   return c.json(
     {
       id: newId,

--- a/functions/api/[[route]].ts
+++ b/functions/api/[[route]].ts
@@ -798,31 +798,44 @@ app.post('/students', auth, loadUser, requireManagerOrAbove, async (c) => {
   const db = getDb(c.env);
   const id = crypto.randomUUID();
 
-  const [activeClassroom] = await db
-    .select({ id: classrooms.id })
-    .from(classrooms)
-    .where(and(eq(classrooms.id, input.classroomId), isNull(classrooms.deletedAt)))
-    .limit(1);
+  type CreateStudentTxResult =
+    | { ok: true }
+    | { ok: false; reason: 'classroom_not_found' };
 
-  if (!activeClassroom) {
-    return c.json({ message: 'classroom not found' }, 404);
-  }
-
+  let txResult: CreateStudentTxResult;
   try {
-    await db.insert(students).values({
-      id,
-      name: input.name,
-      email: input.email,
-      birthYear: input.birthYear,
-      classroomId: input.classroomId,
-      deletedAt: null,
-    });
+    txResult = await db.transaction(
+      async (tx) => {
+        const [activeClassroom] = await tx
+          .select({ id: classrooms.id })
+          .from(classrooms)
+          .where(and(eq(classrooms.id, input.classroomId), isNull(classrooms.deletedAt)))
+          .limit(1);
+        if (!activeClassroom) {
+          return { ok: false as const, reason: 'classroom_not_found' as const };
+        }
+        await tx.insert(students).values({
+          id,
+          name: input.name,
+          email: input.email,
+          birthYear: input.birthYear,
+          classroomId: input.classroomId,
+          deletedAt: null,
+        });
+        return { ok: true as const };
+      },
+      { behavior: 'immediate' },
+    );
   } catch (err) {
     if (isD1ForeignKeyViolation(err)) {
       return c.json({ message: 'classroom not found' }, 404);
     }
     const detail = collectErrorTextParts(err).join(' ') || (err instanceof Error ? err.message : String(err));
     return c.json({ message: 'failed to create student', detail }, 500);
+  }
+
+  if (!txResult.ok) {
+    return c.json({ message: 'classroom not found' }, 404);
   }
 
   return c.json(

--- a/functions/api/[[route]].ts
+++ b/functions/api/[[route]].ts
@@ -106,6 +106,13 @@ function isD1ForeignKeyViolation(error: unknown): boolean {
   return text.includes('foreign key');
 }
 
+/** 診断用（Wrangler / ダッシュボードのログ）。クライアントには返さない。 */
+function logApiError(routeLabel: string, err: unknown): void {
+  const summary =
+    collectErrorTextParts(err).join(' ') || (err instanceof Error ? err.message : String(err));
+  console.error(`[api] ${routeLabel}: ${summary}`, err);
+}
+
 export const app = new Hono<{ Bindings: Bindings; Variables: AppVariables }>().basePath('/api');
 
 const getAuth0ManagementToken = async (env: Bindings): Promise<string> => {
@@ -827,11 +834,11 @@ app.post('/students', auth, loadUser, requireManagerOrAbove, async (c) => {
       { behavior: 'immediate' },
     );
   } catch (err) {
+    logApiError('POST /students', err);
     if (isD1ForeignKeyViolation(err)) {
       return c.json({ message: 'classroom not found' }, 404);
     }
-    const detail = collectErrorTextParts(err).join(' ') || (err instanceof Error ? err.message : String(err));
-    return c.json({ message: 'failed to create student', detail }, 500);
+    return c.json({ message: 'failed to create student' }, 500);
   }
 
   if (!txResult.ok) {
@@ -1000,11 +1007,11 @@ app.post('/subjects', auth, loadUser, requireManagerOrAbove, async (c) => {
       deletedAt: null,
     });
   } catch (err) {
+    logApiError('POST /subjects', err);
     if (isD1ForeignKeyViolation(err)) {
       return c.json({ message: 'classroom not found' }, 404);
     }
-    const detail = collectErrorTextParts(err).join(' ') || (err instanceof Error ? err.message : String(err));
-    return c.json({ message: 'failed to create subject', detail }, 500);
+    return c.json({ message: 'failed to create subject' }, 500);
   }
   return c.json({ id: newId, name: input.name, classroomId: input.classroomId }, 201);
 });
@@ -1037,11 +1044,11 @@ app.post('/lesson-types', auth, loadUser, requireManagerOrAbove, async (c) => {
       deletedAt: null,
     });
   } catch (err) {
+    logApiError('POST /lesson-types', err);
     if (isD1ForeignKeyViolation(err)) {
       return c.json({ message: 'classroom not found' }, 404);
     }
-    const detail = collectErrorTextParts(err).join(' ') || (err instanceof Error ? err.message : String(err));
-    return c.json({ message: 'failed to create lesson type', detail }, 500);
+    return c.json({ message: 'failed to create lesson type' }, 500);
   }
   return c.json({ id: newId, name: input.name, classroomId: input.classroomId }, 201);
 });
@@ -1075,11 +1082,11 @@ app.post('/time-slots', auth, loadUser, requireManagerOrAbove, async (c) => {
       deletedAt: null,
     });
   } catch (err) {
+    logApiError('POST /time-slots', err);
     if (isD1ForeignKeyViolation(err)) {
       return c.json({ message: 'classroom not found' }, 404);
     }
-    const detail = collectErrorTextParts(err).join(' ') || (err instanceof Error ? err.message : String(err));
-    return c.json({ message: 'failed to create time slot', detail }, 500);
+    return c.json({ message: 'failed to create time slot' }, 500);
   }
   return c.json(
     {

--- a/functions/api/classrooms.test.ts
+++ b/functions/api/classrooms.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { classrooms, students, users } from '../../db/schema';
+import { classrooms, lessonTypes, students, subjects, timeSlots, users } from '../../db/schema';
 
 type ClassroomRow = {
   id: string;
@@ -19,10 +19,17 @@ type ClassroomStudentRow = {
   deletedAt: Date | null;
 };
 
+type PresetSubjectRow = { id: string; classroomId: string; deletedAt: Date | null };
+type PresetLessonTypeRow = { id: string; classroomId: string; deletedAt: Date | null };
+type PresetTimeSlotRow = { id: string; classroomId: string; deletedAt: Date | null };
+
 const state: {
   classrooms: ClassroomRow[];
   classroomUsers: ClassroomUserRow[];
   classroomStudents: ClassroomStudentRow[];
+  presetSubjects: PresetSubjectRow[];
+  presetLessonTypes: PresetLessonTypeRow[];
+  presetTimeSlots: PresetTimeSlotRow[];
   userRole: 'admin' | 'manager' | 'staff' | null;
   jwtSub: string | null;
   deleteAuth0Ok: boolean;
@@ -31,15 +38,24 @@ const state: {
   deleteAuth0FailAfterSuccessCount?: number;
   /** Simulates D1 unique violation on classroom insert (e.g. race after preflight). */
   insertSimulateClassroomUniqueViolation: boolean;
+  /** First soft-delete of a preset subject inside DELETE /classrooms tx throws (for rollback test). */
+  throwOnPresetSubjectSoftDelete: boolean;
+  /** Snapshot/restore D1 state on transaction failure (simulates SQL rollback in mock). */
+  snapshotDbStateOnTransactionFailure: boolean;
 } = {
   classrooms: [],
   classroomUsers: [],
   classroomStudents: [],
+  presetSubjects: [],
+  presetLessonTypes: [],
+  presetTimeSlots: [],
   userRole: 'admin',
   jwtSub: 'auth0|admin-user',
   deleteAuth0Ok: true,
   deletedAuth0UserIds: [],
   insertSimulateClassroomUniqueViolation: false,
+  throwOnPresetSubjectSoftDelete: false,
+  snapshotDbStateOnTransactionFailure: false,
 };
 
 vi.mock('hono/jwk', () => {
@@ -152,6 +168,57 @@ vi.mock('../../db', () => {
           };
         }
 
+        if (table === subjects) {
+          const keys = Object.keys(selection);
+          if (keys.length === 1 && keys.includes('id')) {
+            return {
+              where: async (predicate: unknown) => {
+                const classroomId = extractRequestedId(predicate);
+                return state.presetSubjects
+                  .filter((row) => row.classroomId === classroomId && row.deletedAt === null)
+                  .map((row) => ({ id: row.id }));
+              },
+            };
+          }
+          return {
+            where: async () => [],
+          };
+        }
+
+        if (table === lessonTypes) {
+          const keys = Object.keys(selection);
+          if (keys.length === 1 && keys.includes('id')) {
+            return {
+              where: async (predicate: unknown) => {
+                const classroomId = extractRequestedId(predicate);
+                return state.presetLessonTypes
+                  .filter((row) => row.classroomId === classroomId && row.deletedAt === null)
+                  .map((row) => ({ id: row.id }));
+              },
+            };
+          }
+          return {
+            where: async () => [],
+          };
+        }
+
+        if (table === timeSlots) {
+          const keys = Object.keys(selection);
+          if (keys.length === 1 && keys.includes('id')) {
+            return {
+              where: async (predicate: unknown) => {
+                const classroomId = extractRequestedId(predicate);
+                return state.presetTimeSlots
+                  .filter((row) => row.classroomId === classroomId && row.deletedAt === null)
+                  .map((row) => ({ id: row.id }));
+              },
+            };
+          }
+          return {
+            where: async () => [],
+          };
+        }
+
         if (table === classrooms) {
           const keys = Object.keys(selection);
           if (keys.length === 1 && keys.includes('id')) {
@@ -244,11 +311,82 @@ vi.mock('../../db', () => {
             return { meta: { changes: 1 } };
           }
 
+          if (table === subjects) {
+            const requestedId = extractRequestedId(predicate);
+            if (!requestedId) {
+              return { meta: { changes: 0 } };
+            }
+            const target = state.presetSubjects.find(
+              (row) => row.id === requestedId && (value.deletedAt === null || row.deletedAt === null),
+            );
+            if (!target) {
+              return { meta: { changes: 0 } };
+            }
+            if (value.deletedAt !== null && state.throwOnPresetSubjectSoftDelete) {
+              throw new Error('simulated preset subject soft-delete failure');
+            }
+            target.deletedAt = value.deletedAt;
+            return { meta: { changes: 1 } };
+          }
+
+          if (table === lessonTypes) {
+            const requestedId = extractRequestedId(predicate);
+            if (!requestedId) {
+              return { meta: { changes: 0 } };
+            }
+            const target = state.presetLessonTypes.find(
+              (row) => row.id === requestedId && (value.deletedAt === null || row.deletedAt === null),
+            );
+            if (!target) {
+              return { meta: { changes: 0 } };
+            }
+            target.deletedAt = value.deletedAt;
+            return { meta: { changes: 1 } };
+          }
+
+          if (table === timeSlots) {
+            const requestedId = extractRequestedId(predicate);
+            if (!requestedId) {
+              return { meta: { changes: 0 } };
+            }
+            const target = state.presetTimeSlots.find(
+              (row) => row.id === requestedId && (value.deletedAt === null || row.deletedAt === null),
+            );
+            if (!target) {
+              return { meta: { changes: 0 } };
+            }
+            target.deletedAt = value.deletedAt;
+            return { meta: { changes: 1 } };
+          }
+
           return { meta: { changes: 0 } };
         },
       }),
     }),
-    transaction: async <T>(fn: (tx: typeof db) => Promise<T>) => fn(db),
+    transaction: async <T>(fn: (tx: typeof db) => Promise<T>) => {
+      if (!state.snapshotDbStateOnTransactionFailure) {
+        return fn(db);
+      }
+      const snap = {
+        classrooms: structuredClone(state.classrooms),
+        classroomUsers: structuredClone(state.classroomUsers),
+        classroomStudents: structuredClone(state.classroomStudents),
+        presetSubjects: structuredClone(state.presetSubjects),
+        presetLessonTypes: structuredClone(state.presetLessonTypes),
+        presetTimeSlots: structuredClone(state.presetTimeSlots),
+      };
+      try {
+        return await fn(db);
+      } catch {
+        state.classrooms = snap.classrooms;
+        state.classroomUsers = snap.classroomUsers;
+        state.classroomStudents = snap.classroomStudents;
+        state.presetSubjects = snap.presetSubjects;
+        state.presetLessonTypes = snap.presetLessonTypes;
+        state.presetTimeSlots = snap.presetTimeSlots;
+        throw new Error('transaction aborted');
+      }
+    },
   };
 
   return {
@@ -307,6 +445,11 @@ describe('classrooms api flow', () => {
     state.deletedAuth0UserIds = [];
     state.deleteAuth0FailAfterSuccessCount = undefined;
     state.insertSimulateClassroomUniqueViolation = false;
+    state.presetSubjects = [];
+    state.presetLessonTypes = [];
+    state.presetTimeSlots = [];
+    state.throwOnPresetSubjectSoftDelete = false;
+    state.snapshotDbStateOnTransactionFailure = false;
     fetchMock.mockClear();
   });
 
@@ -513,6 +656,45 @@ describe('classrooms api flow', () => {
       method: 'DELETE',
     }, env);
     expect(secondDelete.status).toBe(404);
+  });
+
+  it('soft-deletes preset subjects, lesson types, and time slots when deleting classroom', async () => {
+    const postResponse = await app.request('/api/classrooms', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Class With Presets' }),
+    }, env);
+    const created = (await postResponse.json()) as { id: string };
+
+    state.presetSubjects.push({ id: 'ps-1', classroomId: created.id, deletedAt: null });
+    state.presetLessonTypes.push({ id: 'plt-1', classroomId: created.id, deletedAt: null });
+    state.presetTimeSlots.push({ id: 'pts-1', classroomId: created.id, deletedAt: null });
+
+    const deleteResponse = await app.request(`/api/classrooms/${created.id}`, { method: 'DELETE' }, env);
+    expect(deleteResponse.status).toBe(200);
+    expect(state.classrooms.find((r) => r.id === created.id)?.deletedAt).toBeInstanceOf(Date);
+    expect(state.presetSubjects[0]?.deletedAt).toBeInstanceOf(Date);
+    expect(state.presetLessonTypes[0]?.deletedAt).toBeInstanceOf(Date);
+    expect(state.presetTimeSlots[0]?.deletedAt).toBeInstanceOf(Date);
+  });
+
+  it('returns 400 and restores D1 state when preset subject soft-delete fails inside delete transaction', async () => {
+    const postResponse = await app.request('/api/classrooms', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name: 'Class Preset Tx Fail' }),
+    }, env);
+    const created = (await postResponse.json()) as { id: string };
+
+    state.presetSubjects.push({ id: 'ps-fail', classroomId: created.id, deletedAt: null });
+    state.snapshotDbStateOnTransactionFailure = true;
+    state.throwOnPresetSubjectSoftDelete = true;
+
+    const deleteResponse = await app.request(`/api/classrooms/${created.id}`, { method: 'DELETE' }, env);
+    expect(deleteResponse.status).toBe(400);
+
+    expect(state.classrooms.find((r) => r.id === created.id)?.deletedAt).toBeNull();
+    expect(state.presetSubjects[0]?.deletedAt).toBeNull();
   });
 
   it('returns 403 for manager and staff users', async () => {

--- a/functions/api/presets.test.ts
+++ b/functions/api/presets.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { classrooms, lessonTypes, subjects, timeSlots, users } from '../../db/schema';
 
+/** 教室削除時のプリセット連鎖ソフトデリートは `classrooms.test.ts` で検証（DELETE /classrooms 用モックは同ファイルに集約）。 */
+
 type ClassroomRow = { id: string; deletedAt: Date | null };
 type SubjectRow = { id: string; name: string; classroomId: string; deletedAt: Date | null };
 type LessonTypeRow = { id: string; name: string; classroomId: string; deletedAt: Date | null };
@@ -460,6 +462,23 @@ describe('presets api', () => {
             classroomId: 'room-1',
             startTime: '18:00',
             endTime: '17:00',
+          }),
+        },
+        env,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('POST rejects out-of-range clock values (no clamping)', async () => {
+      const res = await app.request(
+        '/api/time-slots',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            classroomId: 'room-1',
+            startTime: '25:00',
+            endTime: '26:00',
           }),
         },
         env,

--- a/functions/api/presets.test.ts
+++ b/functions/api/presets.test.ts
@@ -1,0 +1,522 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { classrooms, lessonTypes, subjects, timeSlots, users } from '../../db/schema';
+
+type ClassroomRow = { id: string; deletedAt: Date | null };
+type SubjectRow = { id: string; name: string; classroomId: string; deletedAt: Date | null };
+type LessonTypeRow = { id: string; name: string; classroomId: string; deletedAt: Date | null };
+type TimeSlotRow = {
+  id: string;
+  classroomId: string;
+  startTime: string;
+  endTime: string;
+  deletedAt: Date | null;
+};
+
+const state: {
+  userRole: 'admin' | 'manager' | 'staff' | null;
+  jwtSub: string;
+  classrooms: ClassroomRow[];
+  subjectRows: SubjectRow[];
+  lessonTypeRows: LessonTypeRow[];
+  timeSlotRows: TimeSlotRow[];
+} = {
+  userRole: 'admin',
+  jwtSub: 'auth0|admin-user',
+  classrooms: [],
+  subjectRows: [],
+  lessonTypeRows: [],
+  timeSlotRows: [],
+};
+
+vi.mock('hono/jwk', () => {
+  return {
+    jwk: () => {
+      return async (c: { set: (key: string, value: unknown) => void }, next: () => Promise<void>) => {
+        c.set('jwtPayload', { sub: state.jwtSub });
+        await next();
+      };
+    },
+  };
+});
+
+vi.mock('../../db', () => {
+  const extractRequestedId = (predicate: unknown): string | null => {
+    if (typeof predicate === 'string') {
+      return predicate;
+    }
+    const visited = new Set<object>();
+    const stack: unknown[] = [predicate];
+    while (stack.length > 0) {
+      const current = stack.pop();
+      if (!current || typeof current !== 'object') {
+        continue;
+      }
+      if (visited.has(current)) {
+        continue;
+      }
+      visited.add(current);
+      const candidate = (current as { value?: unknown }).value;
+      if (typeof candidate === 'string') {
+        return candidate;
+      }
+      for (const value of Object.values(current)) {
+        stack.push(value);
+      }
+    }
+    return null;
+  };
+
+  const dbCore = {
+    select: (selection: Record<string, unknown>) => ({
+      from: (table: unknown) => {
+        if (table === classrooms) {
+          return {
+            where: (predicate: unknown) => ({
+              limit: async () => {
+                const requestedId = extractRequestedId(predicate);
+                const classroom = state.classrooms.find(
+                  (r) => r.id === requestedId && r.deletedAt === null,
+                );
+                return classroom ? [{ id: classroom.id }] : [];
+              },
+            }),
+          };
+        }
+
+        if (table === users) {
+          const keys = Object.keys(selection);
+          if (keys.length === 3 && keys.includes('id') && keys.includes('role') && keys.includes('classroomId')) {
+            return {
+              where: () => ({
+                limit: async () =>
+                  state.userRole
+                    ? [
+                        {
+                          id: state.jwtSub,
+                          role: state.userRole,
+                          classroomId: state.userRole === 'admin' ? null : 'room-1',
+                        },
+                      ]
+                    : [],
+              }),
+            };
+          }
+          return { where: () => ({ limit: async () => [] }) };
+        }
+
+        if (table === subjects) {
+          const keys = Object.keys(selection);
+          if (keys.includes('name') && keys.includes('id')) {
+            return {
+              where: async (predicate: unknown) => {
+                const classroomId = extractRequestedId(predicate);
+                return state.subjectRows
+                  .filter((r) => r.classroomId === classroomId && r.deletedAt === null)
+                  .map((r) => ({ id: r.id, name: r.name }));
+              },
+            };
+          }
+          return {
+            where: (predicate: unknown) => ({
+              limit: async () => {
+                const targetId = extractRequestedId(predicate);
+                const row = state.subjectRows.find(
+                  (r) => r.id === targetId && r.deletedAt === null,
+                );
+                return row ? [{ id: row.id, classroomId: row.classroomId }] : [];
+              },
+            }),
+          };
+        }
+
+        if (table === lessonTypes) {
+          const keys = Object.keys(selection);
+          if (keys.includes('name') && keys.includes('id')) {
+            return {
+              where: async (predicate: unknown) => {
+                const classroomId = extractRequestedId(predicate);
+                return state.lessonTypeRows
+                  .filter((r) => r.classroomId === classroomId && r.deletedAt === null)
+                  .map((r) => ({ id: r.id, name: r.name }));
+              },
+            };
+          }
+          return {
+            where: (predicate: unknown) => ({
+              limit: async () => {
+                const targetId = extractRequestedId(predicate);
+                const row = state.lessonTypeRows.find(
+                  (r) => r.id === targetId && r.deletedAt === null,
+                );
+                return row ? [{ id: row.id, classroomId: row.classroomId }] : [];
+              },
+            }),
+          };
+        }
+
+        if (table === timeSlots) {
+          const keys = Object.keys(selection);
+          if (keys.includes('classroomId') && keys.includes('startTime')) {
+            return {
+              where: (predicate: unknown) => ({
+                limit: async () => {
+                  const targetId = extractRequestedId(predicate);
+                  const row = state.timeSlotRows.find(
+                    (r) => r.id === targetId && r.deletedAt === null,
+                  );
+                  return row
+                    ? [
+                        {
+                          id: row.id,
+                          classroomId: row.classroomId,
+                          startTime: row.startTime,
+                          endTime: row.endTime,
+                        },
+                      ]
+                    : [];
+                },
+              }),
+            };
+          }
+          if (keys.includes('startTime') && keys.includes('endTime')) {
+            return {
+              where: async (predicate: unknown) => {
+                const classroomId = extractRequestedId(predicate);
+                return state.timeSlotRows
+                  .filter((r) => r.classroomId === classroomId && r.deletedAt === null)
+                  .map((r) => ({
+                    id: r.id,
+                    startTime: r.startTime,
+                    endTime: r.endTime,
+                  }));
+              },
+            };
+          }
+          return { where: () => ({ limit: async () => [] }) };
+        }
+
+        return { where: () => ({ limit: async () => [] }) };
+      },
+    }),
+    insert: (table: unknown) => ({
+      values: async (value: SubjectRow | LessonTypeRow | TimeSlotRow) => {
+        if (table === subjects) {
+          state.subjectRows.push(value as SubjectRow);
+        } else if (table === lessonTypes) {
+          state.lessonTypeRows.push(value as LessonTypeRow);
+        } else if (table === timeSlots) {
+          state.timeSlotRows.push(value as TimeSlotRow);
+        }
+      },
+    }),
+    update: (table: unknown) => ({
+      set: (value: {
+        deletedAt?: Date | null;
+        name?: string;
+        startTime?: string;
+        endTime?: string;
+      }) => ({
+        where: async (predicate: unknown) => {
+          const requestedId = extractRequestedId(predicate);
+          const apply = <T extends { id: string; deletedAt: Date | null }>(
+            rows: T[],
+            patch: (row: T) => void,
+          ) => {
+            const row = rows.find(
+              (r) =>
+                r.id === requestedId &&
+                (value.deletedAt === undefined || r.deletedAt === null),
+            );
+            if (!row) {
+              return { meta: { changes: 0 } };
+            }
+            patch(row);
+            return { meta: { changes: 1 } };
+          };
+
+          if (table === subjects) {
+            return apply(state.subjectRows, (row) => {
+              if (value.name !== undefined) {
+                row.name = value.name;
+              }
+              if (value.deletedAt !== undefined) {
+                row.deletedAt = value.deletedAt;
+              }
+            });
+          }
+          if (table === lessonTypes) {
+            return apply(state.lessonTypeRows, (row) => {
+              if (value.name !== undefined) {
+                row.name = value.name;
+              }
+              if (value.deletedAt !== undefined) {
+                row.deletedAt = value.deletedAt;
+              }
+            });
+          }
+          if (table === timeSlots) {
+            return apply(state.timeSlotRows, (row) => {
+              if (value.startTime !== undefined) {
+                row.startTime = value.startTime;
+              }
+              if (value.endTime !== undefined) {
+                row.endTime = value.endTime;
+              }
+              if (value.deletedAt !== undefined) {
+                row.deletedAt = value.deletedAt;
+              }
+            });
+          }
+          return { meta: { changes: 0 } };
+        },
+      }),
+    }),
+  };
+
+  const db = {
+    ...dbCore,
+    transaction: async <T>(callback: (tx: typeof dbCore) => Promise<T>): Promise<T> => callback(dbCore),
+  };
+
+  return { getDb: () => db };
+});
+
+import { app } from './[[route]]';
+
+const env = {
+  AUTH0_AUDIENCE: 'https://api.example.local',
+  AUTH0_ISSUER: 'https://issuer.example.local/',
+  AUTH0_JWKS_URI: 'https://issuer.example.local/.well-known/jwks.json',
+  VITE_AUTH0_DOMAIN: 'tenant.example.auth0.com',
+  AUTH0_M2M_CLIENT_ID: 'm2m-client-id',
+  AUTH0_M2M_CLIENT_SECRET: 'm2m-client-secret',
+  AUTH0_DB_CONNECTION: 'Username-Password-Authentication',
+  VITE_AUTH0_CLIENT_ID: 'spa-client-id',
+  DB: {},
+} as unknown as Env;
+
+describe('presets api', () => {
+  beforeEach(() => {
+    state.userRole = 'admin';
+    state.jwtSub = 'auth0|admin-user';
+    state.classrooms = [
+      { id: 'room-1', deletedAt: null },
+      { id: 'room-2', deletedAt: null },
+    ];
+    state.subjectRows = [
+      {
+        id: 'sub-1',
+        name: '英語',
+        classroomId: 'room-1',
+        deletedAt: null,
+      },
+      {
+        id: 'sub-del',
+        name: '削除済',
+        classroomId: 'room-1',
+        deletedAt: new Date(),
+      },
+    ];
+    state.lessonTypeRows = [{ id: 'lt-1', name: '通常', classroomId: 'room-1', deletedAt: null }];
+    state.timeSlotRows = [
+      {
+        id: 'ts-1',
+        classroomId: 'room-1',
+        startTime: '17:00',
+        endTime: '18:30',
+        deletedAt: null,
+      },
+    ];
+    vi.stubGlobal('crypto', {
+      randomUUID: () => '00000000-0000-4000-8000-0000000000aa',
+    } as Crypto);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe('GET lists', () => {
+    it('lists active subjects for classroom', async () => {
+      const res = await app.request('/api/classrooms/room-1/subjects', { method: 'GET' }, env);
+      expect(res.status).toBe(200);
+      const rows = (await res.json()) as Array<{ id: string; name: string }>;
+      expect(rows.map((r) => r.id)).toContain('sub-1');
+      expect(rows.some((r) => r.id === 'sub-del')).toBe(false);
+    });
+
+    it('returns 403 when manager requests another classroom subjects', async () => {
+      state.userRole = 'manager';
+      state.jwtSub = 'auth0|manager-user';
+      const res = await app.request('/api/classrooms/room-2/subjects', { method: 'GET' }, env);
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 403 for staff', async () => {
+      state.userRole = 'staff';
+      state.jwtSub = 'auth0|staff-user';
+      const res = await app.request('/api/classrooms/room-1/subjects', { method: 'GET' }, env);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe('POST /subjects', () => {
+    it('creates subject as admin', async () => {
+      const before = state.subjectRows.length;
+      const res = await app.request(
+        '/api/subjects',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: '数学', classroomId: 'room-1' }),
+        },
+        env,
+      );
+      expect(res.status).toBe(201);
+      expect(state.subjectRows.length).toBe(before + 1);
+      expect(state.subjectRows.some((r) => r.name === '数学')).toBe(true);
+    });
+
+    it('returns 403 when manager targets another classroom', async () => {
+      state.userRole = 'manager';
+      state.jwtSub = 'auth0|manager-user';
+      const res = await app.request(
+        '/api/subjects',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: '数学', classroomId: 'room-2' }),
+        },
+        env,
+      );
+      expect(res.status).toBe(403);
+    });
+
+    it('returns 404 when classroom missing', async () => {
+      const res = await app.request(
+        '/api/subjects',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: '数学', classroomId: 'room-missing' }),
+        },
+        env,
+      );
+      expect(res.status).toBe(404);
+    });
+  });
+
+  describe('PATCH /subjects/:id', () => {
+    it('updates name when scoped', async () => {
+      const res = await app.request(
+        '/api/subjects/sub-1',
+        {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: '英語A' }),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(state.subjectRows.find((r) => r.id === 'sub-1')?.name).toBe('英語A');
+    });
+  });
+
+  describe('DELETE /subjects/:id', () => {
+    it('soft-deletes subject', async () => {
+      const res = await app.request('/api/subjects/sub-1', { method: 'DELETE' }, env);
+      expect(res.status).toBe(200);
+      expect(state.subjectRows.find((r) => r.id === 'sub-1')?.deletedAt).toBeInstanceOf(Date);
+    });
+  });
+
+  describe('lesson-types', () => {
+    it('POST and GET', async () => {
+      const post = await app.request(
+        '/api/lesson-types',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name: '振替', classroomId: 'room-1' }),
+        },
+        env,
+      );
+      expect(post.status).toBe(201);
+      const get = await app.request('/api/classrooms/room-1/lesson-types', { method: 'GET' }, env);
+      expect(get.status).toBe(200);
+      const rows = (await get.json()) as Array<{ name: string }>;
+      expect(rows.some((r) => r.name === '振替')).toBe(true);
+    });
+  });
+
+  describe('time-slots', () => {
+    it('POST validates end after start', async () => {
+      const res = await app.request(
+        '/api/time-slots',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            classroomId: 'room-1',
+            startTime: '18:00',
+            endTime: '17:00',
+          }),
+        },
+        env,
+      );
+      expect(res.status).toBe(400);
+    });
+
+    it('POST creates time slot', async () => {
+      const res = await app.request(
+        '/api/time-slots',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            classroomId: 'room-1',
+            startTime: '09:00',
+            endTime: '10:00',
+          }),
+        },
+        env,
+      );
+      expect(res.status).toBe(201);
+      expect(state.timeSlotRows.some((r) => r.startTime === '09:00')).toBe(true);
+    });
+
+    it('POST accepts HH:mm:ss and stores HH:mm', async () => {
+      const res = await app.request(
+        '/api/time-slots',
+        {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({
+            classroomId: 'room-1',
+            startTime: '09:00:00',
+            endTime: '10:30:00',
+          }),
+        },
+        env,
+      );
+      expect(res.status).toBe(201);
+      expect(
+        state.timeSlotRows.some((r) => r.startTime === '09:00' && r.endTime === '10:30'),
+      ).toBe(true);
+    });
+
+    it('PATCH partial time', async () => {
+      const res = await app.request(
+        '/api/time-slots/ts-1',
+        {
+          method: 'PATCH',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ endTime: '19:00' }),
+        },
+        env,
+      );
+      expect(res.status).toBe(200);
+      expect(state.timeSlotRows.find((r) => r.id === 'ts-1')?.endTime).toBe('19:00');
+    });
+  });
+});

--- a/functions/api/students.test.ts
+++ b/functions/api/students.test.ts
@@ -297,7 +297,7 @@ describe('students api', () => {
       expect(response.status).toBe(404);
     });
 
-    it('returns 400 when insert fails', async () => {
+    it('returns 500 when insert fails', async () => {
       state.insertStudentThrows = true;
       const response = await app.request(
         '/api/students',
@@ -308,7 +308,7 @@ describe('students api', () => {
         },
         env,
       );
-      expect(response.status).toBe(400);
+      expect(response.status).toBe(500);
     });
 
     it('returns 403 for staff', async () => {

--- a/functions/api/validators.ts
+++ b/functions/api/validators.ts
@@ -30,18 +30,107 @@ const userSchema = z
     }
   });
 
-const currentYear = new Date().getFullYear();
+const studentSchema = z
+  .object({
+    name: z.string().trim().min(1, 'name is required').max(100, 'name must be 100 characters or less'),
+    email: z.string().trim().pipe(z.email('invalid email')),
+    birthYear: z.coerce
+      .number()
+      .int('birth year must be an integer')
+      .min(1900, 'birth year is out of range'),
+    classroomId: z.string().trim().min(1, 'classroom id is required'),
+  })
+  .superRefine((data, ctx) => {
+    const maxYear = new Date().getFullYear();
+    if (data.birthYear > maxYear) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['birthYear'],
+        message: 'birth year is out of range',
+      });
+    }
+  });
 
-const studentSchema = z.object({
+/** `<input type="time">` の `HH:mm:ss` や 1 桁時刻を `HH:mm` に揃えてから検証する */
+function normalizeToHm24(raw: string): string {
+  const trimmed = raw.trim();
+  const parts = trimmed.split(':');
+  if (parts.length < 2) {
+    return trimmed;
+  }
+  const h = Number.parseInt(parts[0] ?? '0', 10);
+  const m = Number.parseInt(parts[1] ?? '0', 10);
+  if (Number.isNaN(h) || Number.isNaN(m)) {
+    return trimmed;
+  }
+  const hh = Math.min(23, Math.max(0, h));
+  const mm = Math.min(59, Math.max(0, m));
+  return `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}`;
+}
+
+/** `HH:mm` 24h（秒付きや 1 桁時は正規化して受理） */
+const hmTimeSchema = z
+  .string()
+  .transform(normalizeToHm24)
+  .pipe(z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, 'invalid time format (use HH:mm)'));
+
+function parseHmToMinutes(s: string): number {
+  const [h, m] = s.split(':').map(Number);
+  return h * 60 + m;
+}
+
+const presetNameBodySchema = z.object({
   name: z.string().trim().min(1, 'name is required').max(100, 'name must be 100 characters or less'),
-  email: z.string().trim().pipe(z.email('invalid email')),
-  birthYear: z.coerce
-    .number()
-    .int('birth year must be an integer')
-    .min(1900, 'birth year is out of range')
-    .max(currentYear, 'birth year is out of range'),
   classroomId: z.string().trim().min(1, 'classroom id is required'),
 });
+
+const createTimeSlotSchema = z
+  .object({
+    classroomId: z.string().trim().min(1, 'classroom id is required'),
+    startTime: hmTimeSchema,
+    endTime: hmTimeSchema,
+  })
+  .superRefine((v, ctx) => {
+    if (parseHmToMinutes(v.startTime) >= parseHmToMinutes(v.endTime)) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['endTime'],
+        message: 'end time must be after start time',
+      });
+    }
+  });
+
+const patchSubjectSchema = z.object({
+  name: z.string().trim().min(1, 'name is required').max(100, 'name must be 100 characters or less'),
+});
+
+const patchLessonTypeSchema = patchSubjectSchema;
+
+const patchTimeSlotSchema = z
+  .object({
+    startTime: hmTimeSchema.optional(),
+    endTime: hmTimeSchema.optional(),
+  })
+  .superRefine((v, ctx) => {
+    if (v.startTime === undefined && v.endTime === undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['startTime'],
+        message: 'at least one of startTime or endTime is required',
+      });
+    }
+  })
+  .superRefine((v, ctx) => {
+    if (v.startTime !== undefined && v.endTime !== undefined) {
+      if (parseHmToMinutes(v.startTime) >= parseHmToMinutes(v.endTime)) {
+        ctx.addIssue({
+          code: 'custom',
+          path: ['endTime'],
+          message: 'end time must be after start time',
+        });
+      }
+    }
+  });
 
 type CreateClassroomInput = z.infer<typeof classroomSchema>;
 type CreateUserInput = {
@@ -53,6 +142,11 @@ type CreateUserInput = {
   role: 'admin' | 'manager' | 'staff';
 };
 type CreateStudentInput = z.infer<typeof studentSchema>;
+type CreatePresetNameInput = z.infer<typeof presetNameBodySchema>;
+type CreateTimeSlotInput = z.infer<typeof createTimeSlotSchema>;
+type PatchSubjectInput = z.infer<typeof patchSubjectSchema>;
+type PatchLessonTypeInput = z.infer<typeof patchLessonTypeSchema>;
+type PatchTimeSlotInput = z.infer<typeof patchTimeSlotSchema>;
 
 function firstIssueMessage(error: z.ZodError): string {
   return error.issues[0]?.message ?? 'invalid request';
@@ -92,6 +186,62 @@ export function validateCreateStudentInput(
   body: unknown,
 ): { input?: CreateStudentInput; error?: string } {
   const result = studentSchema.safeParse(body);
+  if (!result.success) {
+    return { error: firstIssueMessage(result.error) };
+  }
+  return { input: result.data };
+}
+
+export function validateCreateSubjectInput(
+  body: unknown,
+): { input?: CreatePresetNameInput; error?: string } {
+  const result = presetNameBodySchema.safeParse(body);
+  if (!result.success) {
+    return { error: firstIssueMessage(result.error) };
+  }
+  return { input: result.data };
+}
+
+export function validateCreateLessonTypeInput(
+  body: unknown,
+): { input?: CreatePresetNameInput; error?: string } {
+  return validateCreateSubjectInput(body);
+}
+
+export function validateCreateTimeSlotInput(
+  body: unknown,
+): { input?: CreateTimeSlotInput; error?: string } {
+  const result = createTimeSlotSchema.safeParse(body);
+  if (!result.success) {
+    return { error: firstIssueMessage(result.error) };
+  }
+  return { input: result.data };
+}
+
+export function validatePatchSubjectInput(
+  body: unknown,
+): { input?: PatchSubjectInput; error?: string } {
+  const result = patchSubjectSchema.safeParse(body);
+  if (!result.success) {
+    return { error: firstIssueMessage(result.error) };
+  }
+  return { input: result.data };
+}
+
+export function validatePatchLessonTypeInput(
+  body: unknown,
+): { input?: PatchLessonTypeInput; error?: string } {
+  const result = patchLessonTypeSchema.safeParse(body);
+  if (!result.success) {
+    return { error: firstIssueMessage(result.error) };
+  }
+  return { input: result.data };
+}
+
+export function validatePatchTimeSlotInput(
+  body: unknown,
+): { input?: PatchTimeSlotInput; error?: string } {
+  const result = patchTimeSlotSchema.safeParse(body);
   if (!result.success) {
     return { error: firstIssueMessage(result.error) };
   }

--- a/functions/api/validators.ts
+++ b/functions/api/validators.ts
@@ -51,24 +51,35 @@ const studentSchema = z
     }
   });
 
-/** `<input type="time">` の `HH:mm:ss` や 1 桁時刻を `HH:mm` に揃えてから検証する */
+/** H:MM / HH:MM / …:SS を HH:mm に揃える。範囲外・不正形はクランプせずそのまま返し、後段の regex で弾く */
+const HM_NORMALIZE_PATTERN = /^(\d{1,2}):(\d{2})(?::(\d{2}))?$/;
+
 function normalizeToHm24(raw: string): string {
   const trimmed = raw.trim();
-  const parts = trimmed.split(':');
-  if (parts.length < 2) {
+  const match = HM_NORMALIZE_PATTERN.exec(trimmed);
+  if (!match) {
     return trimmed;
   }
-  const h = Number.parseInt(parts[0] ?? '0', 10);
-  const m = Number.parseInt(parts[1] ?? '0', 10);
-  if (Number.isNaN(h) || Number.isNaN(m)) {
+  const h = Number(match[1]);
+  const minute = Number(match[2]);
+  const second = match[3] !== undefined ? Number(match[3]) : 0;
+  if (
+    Number.isNaN(h) ||
+    Number.isNaN(minute) ||
+    Number.isNaN(second) ||
+    h < 0 ||
+    h > 23 ||
+    minute < 0 ||
+    minute > 59 ||
+    second < 0 ||
+    second > 59
+  ) {
     return trimmed;
   }
-  const hh = Math.min(23, Math.max(0, h));
-  const mm = Math.min(59, Math.max(0, m));
-  return `${String(hh).padStart(2, '0')}:${String(mm).padStart(2, '0')}`;
+  return `${String(h).padStart(2, '0')}:${String(minute).padStart(2, '0')}`;
 }
 
-/** `HH:mm` 24h（秒付きや 1 桁時は正規化して受理） */
+/** `HH:mm` 24h（許容形だけ正規化し、範囲外は後段 regex で拒否） */
 const hmTimeSchema = z
   .string()
   .transform(normalizeToHm24)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ const HomePage = lazy(() => import('./pages/HomePage'));
 const ClassroomPage = lazy(() => import('./pages/ClassroomPage'));
 const TeacherManagementPage = lazy(() => import('./pages/TeacherManagementPage'));
 const StudentManagementPage = lazy(() => import('./pages/StudentManagementPage'));
+const PresetsSettingsPage = lazy(() => import('./pages/PresetsSettingsPage'));
 
 function App() {
   const { isAuthenticated, isLoading, error, user, getAccessTokenSilently } = useAuth0();
@@ -94,6 +95,16 @@ function App() {
             path="/students"
             element={
               <StudentManagementPage
+                currentUser={currentUser}
+                isLoadingCurrentUser={isLoadingCurrentUser}
+                getAccessTokenSilently={getAccessTokenSilently}
+              />
+            }
+          />
+          <Route
+            path="/settings/presets"
+            element={
+              <PresetsSettingsPage
                 currentUser={currentUser}
                 isLoadingCurrentUser={isLoadingCurrentUser}
                 getAccessTokenSilently={getAccessTokenSilently}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -82,6 +82,15 @@ export default function AppShell({
           >
             生徒管理
           </NavLink>
+          <NavLink
+            to="/settings/presets"
+            className={({ isActive }) =>
+              `rounded-lg px-3 py-2 text-sm font-medium transition ${isActive ? 'bg-indigo-500/20 text-indigo-200' : 'bg-slate-800 text-slate-200 hover:bg-slate-700'}`
+            }
+            onClick={() => setIsMenuOpen(false)}
+          >
+            授業プリセット
+          </NavLink>
         </nav>
 
         <div className="grid gap-2 rounded-xl border border-slate-800 bg-slate-950/60 p-4 text-sm md:grid-cols-2">

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -82,15 +82,17 @@ export default function AppShell({
           >
             生徒管理
           </NavLink>
-          <NavLink
-            to="/settings/presets"
-            className={({ isActive }) =>
-              `rounded-lg px-3 py-2 text-sm font-medium transition ${isActive ? 'bg-indigo-500/20 text-indigo-200' : 'bg-slate-800 text-slate-200 hover:bg-slate-700'}`
-            }
-            onClick={() => setIsMenuOpen(false)}
-          >
-            授業プリセット
-          </NavLink>
+          {(role === 'admin' || role === 'manager') && (
+            <NavLink
+              to="/settings/presets"
+              className={({ isActive }) =>
+                `rounded-lg px-3 py-2 text-sm font-medium transition ${isActive ? 'bg-indigo-500/20 text-indigo-200' : 'bg-slate-800 text-slate-200 hover:bg-slate-700'}`
+              }
+              onClick={() => setIsMenuOpen(false)}
+            >
+              授業プリセット
+            </NavLink>
+          )}
         </nav>
 
         <div className="grid gap-2 rounded-xl border border-slate-800 bg-slate-950/60 p-4 text-sm md:grid-cols-2">

--- a/src/components/PresetsSettingsPanel.tsx
+++ b/src/components/PresetsSettingsPanel.tsx
@@ -1,0 +1,582 @@
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import type { CurrentUser } from '../types/currentUser';
+
+/** `<input type="time">` の値を API の `HH:mm` に揃える */
+function toHm(v: string): string {
+  const parts = v.trim().split(':');
+  if (parts.length >= 2) {
+    const h = parts[0]?.padStart(2, '0') ?? '00';
+    const m = (parts[1] ?? '00').slice(0, 2).padStart(2, '0');
+    return `${h}:${m}`;
+  }
+  return v.trim();
+}
+
+async function readPresetApiError(
+  res: Response,
+  options: { fallback: string; invalidRequestHint: string },
+): Promise<string> {
+  const body = (await res.json().catch(() => ({}))) as { message?: string; detail?: string };
+  if (body.message === 'invalid request') {
+    return options.invalidRequestHint;
+  }
+  const detail = typeof body.detail === 'string' ? body.detail : '';
+  if (detail) {
+    return `${options.fallback}: ${detail}`;
+  }
+  if (body.message) {
+    return `${options.fallback}（${body.message}）`;
+  }
+  return options.fallback;
+}
+
+type Classroom = { id: string; name: string };
+type SubjectRow = { id: string; name: string };
+type LessonTypeRow = { id: string; name: string };
+type TimeSlotRow = { id: string; startTime: string; endTime: string };
+
+type Props = {
+  currentUser: CurrentUser;
+  getAccessTokenSilently: () => Promise<string>;
+};
+
+export default function PresetsSettingsPanel({ currentUser, getAccessTokenSilently }: Props) {
+  const isAdmin = currentUser.role === 'admin';
+
+  const [classrooms, setClassrooms] = useState<Classroom[]>([]);
+  const [selectedClassroomId, setSelectedClassroomId] = useState<string>(currentUser.classroomId ?? '');
+  const [subjects, setSubjects] = useState<SubjectRow[]>([]);
+  const [lessonTypes, setLessonTypes] = useState<LessonTypeRow[]>([]);
+  const [timeSlots, setTimeSlots] = useState<TimeSlotRow[]>([]);
+  const [isLoadingClassrooms, setIsLoadingClassrooms] = useState(false);
+  const [isLoadingPresets, setIsLoadingPresets] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [newSubjectName, setNewSubjectName] = useState('');
+  const [newLessonTypeName, setNewLessonTypeName] = useState('');
+  const [newSlotStart, setNewSlotStart] = useState('17:00');
+  const [newSlotEnd, setNewSlotEnd] = useState('18:30');
+
+  const [draftNames, setDraftNames] = useState<Record<string, string>>({});
+  const [draftSlots, setDraftSlots] = useState<Record<string, { start: string; end: string }>>({});
+
+  const activeClassroomId = useMemo(() => {
+    return isAdmin ? selectedClassroomId : (currentUser.classroomId ?? '');
+  }, [currentUser.classroomId, isAdmin, selectedClassroomId]);
+
+  const authedFetch = useCallback(
+    async (path: string, init?: RequestInit) => {
+      const token = await getAccessTokenSilently();
+      return fetch(path, {
+        ...init,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          ...(init?.headers ?? {}),
+        },
+      });
+    },
+    [getAccessTokenSilently],
+  );
+
+  const loadClassrooms = useCallback(async () => {
+    if (!isAdmin) {
+      return;
+    }
+    setIsLoadingClassrooms(true);
+    try {
+      const res = await authedFetch('/api/classrooms');
+      if (!res.ok) {
+        setError('教室一覧の取得に失敗しました。');
+        return;
+      }
+      const data = (await res.json()) as Classroom[];
+      setClassrooms(data);
+      setSelectedClassroomId((prev) => (prev ? prev : (data[0]?.id ?? '')));
+    } catch {
+      setError('教室一覧の取得に失敗しました。');
+    } finally {
+      setIsLoadingClassrooms(false);
+    }
+  }, [authedFetch, isAdmin]);
+
+  const loadPresets = useCallback(async () => {
+    if (!activeClassroomId) {
+      setSubjects([]);
+      setLessonTypes([]);
+      setTimeSlots([]);
+      return;
+    }
+    setIsLoadingPresets(true);
+    setError(null);
+    try {
+      const [sRes, lRes, tRes] = await Promise.all([
+        authedFetch(`/api/classrooms/${activeClassroomId}/subjects`),
+        authedFetch(`/api/classrooms/${activeClassroomId}/lesson-types`),
+        authedFetch(`/api/classrooms/${activeClassroomId}/time-slots`),
+      ]);
+      if (!sRes.ok || !lRes.ok || !tRes.ok) {
+        setError('プリセット一覧の取得に失敗しました。');
+        return;
+      }
+      setSubjects((await sRes.json()) as SubjectRow[]);
+      setLessonTypes((await lRes.json()) as LessonTypeRow[]);
+      setTimeSlots((await tRes.json()) as TimeSlotRow[]);
+      setDraftNames({});
+      setDraftSlots({});
+    } catch {
+      setError('プリセット一覧の取得に失敗しました。');
+    } finally {
+      setIsLoadingPresets(false);
+    }
+  }, [activeClassroomId, authedFetch]);
+
+  useEffect(() => {
+    void loadClassrooms();
+  }, [loadClassrooms]);
+
+  useEffect(() => {
+    void loadPresets();
+  }, [loadPresets]);
+
+  const handleAddSubject = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const name = newSubjectName.trim();
+    if (!name || !activeClassroomId) {
+      return;
+    }
+    setError(null);
+    const res = await authedFetch('/api/subjects', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name, classroomId: activeClassroomId }),
+    });
+    if (!res.ok) {
+      setError(
+        await readPresetApiError(res, {
+          fallback: '科目の追加に失敗しました',
+          invalidRequestHint: '入力内容を確認してください。',
+        }),
+      );
+      return;
+    }
+    setNewSubjectName('');
+    await loadPresets();
+  };
+
+  const handleAddLessonType = async (e: React.FormEvent) => {
+    e.preventDefault();
+    const name = newLessonTypeName.trim();
+    if (!name || !activeClassroomId) {
+      return;
+    }
+    setError(null);
+    const res = await authedFetch('/api/lesson-types', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name, classroomId: activeClassroomId }),
+    });
+    if (!res.ok) {
+      setError(
+        await readPresetApiError(res, {
+          fallback: '授業種別の追加に失敗しました',
+          invalidRequestHint: '入力内容を確認してください。',
+        }),
+      );
+      return;
+    }
+    setNewLessonTypeName('');
+    await loadPresets();
+  };
+
+  const handleAddTimeSlot = async (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!activeClassroomId) {
+      return;
+    }
+    setError(null);
+    const res = await authedFetch('/api/time-slots', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        classroomId: activeClassroomId,
+        startTime: toHm(newSlotStart),
+        endTime: toHm(newSlotEnd),
+      }),
+    });
+    if (!res.ok) {
+      setError(
+        await readPresetApiError(res, {
+          fallback: '時間枠の追加に失敗しました',
+          invalidRequestHint: '時間枠の入力を確認してください。',
+        }),
+      );
+      return;
+    }
+    await loadPresets();
+  };
+
+  const patchSubject = async (id: string) => {
+    const name = (draftNames[id] ?? '').trim();
+    if (!name) {
+      return;
+    }
+    setError(null);
+    const res = await authedFetch(`/api/subjects/${id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    if (!res.ok) {
+      setError('科目の更新に失敗しました。');
+      return;
+    }
+    await loadPresets();
+  };
+
+  const patchLessonType = async (id: string) => {
+    const name = (draftNames[id] ?? '').trim();
+    if (!name) {
+      return;
+    }
+    setError(null);
+    const res = await authedFetch(`/api/lesson-types/${id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    if (!res.ok) {
+      setError('授業種別の更新に失敗しました。');
+      return;
+    }
+    await loadPresets();
+  };
+
+  const patchTimeSlot = async (id: string) => {
+    const d = draftSlots[id];
+    if (!d) {
+      return;
+    }
+    setError(null);
+    const res = await authedFetch(`/api/time-slots/${id}`, {
+      method: 'PATCH',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ startTime: toHm(d.start), endTime: toHm(d.end) }),
+    });
+    if (!res.ok) {
+      setError('時間枠の更新に失敗しました。');
+      return;
+    }
+    await loadPresets();
+  };
+
+  const disableSubject = async (id: string) => {
+    setError(null);
+    const res = await authedFetch(`/api/subjects/${id}`, { method: 'DELETE' });
+    if (!res.ok) {
+      setError('科目の無効化に失敗しました。');
+      return;
+    }
+    await loadPresets();
+  };
+
+  const disableLessonType = async (id: string) => {
+    setError(null);
+    const res = await authedFetch(`/api/lesson-types/${id}`, { method: 'DELETE' });
+    if (!res.ok) {
+      setError('授業種別の無効化に失敗しました。');
+      return;
+    }
+    await loadPresets();
+  };
+
+  const disableTimeSlot = async (id: string) => {
+    setError(null);
+    const res = await authedFetch(`/api/time-slots/${id}`, { method: 'DELETE' });
+    if (!res.ok) {
+      setError('時間枠の無効化に失敗しました。');
+      return;
+    }
+    await loadPresets();
+  };
+
+  if (!isAdmin && !currentUser.classroomId) {
+    return (
+      <p className="text-sm text-slate-400">
+        所属教室が割り当てられていないため、プリセットを設定できません。
+      </p>
+    );
+  }
+
+  return (
+    <section className="space-y-8">
+      <header className="space-y-2 border-b border-slate-800 pb-6">
+        <p className="text-xs font-semibold uppercase tracking-wider text-cyan-400/90">Presets</p>
+        <h2 className="text-xl font-bold tracking-tight text-slate-50 md:text-2xl">授業プリセット</h2>
+        <p className="max-w-2xl text-sm leading-relaxed text-slate-400">
+          科目・授業種別・時間枠の選択肢を教室ごとに管理します。無効化した項目は一覧に表示されず、新規コマで選べなくなります。
+        </p>
+      </header>
+
+      {isAdmin && (
+        <div className="max-w-md space-y-1">
+          <label htmlFor="preset-classroom" className="text-sm text-slate-300">
+            対象教室
+          </label>
+          <select
+            id="preset-classroom"
+            className="w-full rounded-lg border border-slate-700 bg-slate-800 px-3 py-2 text-slate-100 focus:border-cyan-500/60 focus:outline-none focus:ring-2 focus:ring-cyan-500/25"
+            value={selectedClassroomId}
+            onChange={(e) => setSelectedClassroomId(e.target.value)}
+            disabled={isLoadingClassrooms}
+          >
+            <option value="">教室を選択</option>
+            {classrooms.map((c) => (
+              <option key={c.id} value={c.id}>
+                {c.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {error && (
+        <p className="rounded-lg border border-rose-500/30 bg-rose-950/40 px-3 py-2 text-sm text-rose-200" role="alert">
+          {error}
+        </p>
+      )}
+
+      {!activeClassroomId ? (
+        <p className="text-sm text-slate-500">教室を選択するとプリセットを編集できます。</p>
+      ) : isLoadingPresets ? (
+        <p className="text-sm text-slate-400">読み込み中…</p>
+      ) : (
+        <div className="space-y-10">
+          <PresetSection title="科目">
+            <form onSubmit={handleAddSubject} className="flex flex-wrap items-end gap-2">
+              <div className="min-w-[12rem] flex-1">
+                <label htmlFor="new-subject" className="mb-1 block text-xs text-slate-400">
+                  追加
+                </label>
+                <input
+                  id="new-subject"
+                  value={newSubjectName}
+                  onChange={(e) => setNewSubjectName(e.target.value)}
+                  placeholder="例: 英語"
+                  maxLength={100}
+                  className="w-full rounded-lg border border-slate-700 bg-slate-800/80 px-3 py-2 text-slate-100 placeholder:text-slate-500 focus:border-cyan-500/60 focus:outline-none focus:ring-2 focus:ring-cyan-500/25"
+                />
+              </div>
+              <button
+                type="submit"
+                className="rounded-lg bg-cyan-600 px-4 py-2 text-sm font-semibold text-white hover:bg-cyan-500"
+              >
+                追加
+              </button>
+            </form>
+            <ul className="mt-4 space-y-2">
+              {subjects.map((row) => (
+                <li
+                  key={row.id}
+                  className="flex flex-col gap-2 rounded-xl border border-slate-800 bg-slate-950/60 p-3 sm:flex-row sm:items-center"
+                >
+                  <input
+                    aria-label={`科目 ${row.name}`}
+                    value={draftNames[row.id] ?? row.name}
+                    onChange={(e) => setDraftNames((prev) => ({ ...prev, [row.id]: e.target.value }))}
+                    maxLength={100}
+                    className="min-w-0 flex-1 rounded-lg border border-slate-700 bg-slate-800/80 px-3 py-2 text-slate-100"
+                  />
+                  <div className="flex shrink-0 flex-wrap gap-2">
+                    <button
+                      type="button"
+                      className="rounded-lg border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-800"
+                      onClick={() => void patchSubject(row.id)}
+                    >
+                      更新
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-lg border border-rose-500/40 bg-rose-950/50 px-3 py-1.5 text-sm text-rose-200 hover:bg-rose-900/60"
+                      onClick={() => void disableSubject(row.id)}
+                    >
+                      無効化
+                    </button>
+                  </div>
+                </li>
+              ))}
+              {subjects.length === 0 && (
+                <li className="text-sm text-slate-500">科目がまだありません。</li>
+              )}
+            </ul>
+          </PresetSection>
+
+          <PresetSection title="授業種別">
+            <form onSubmit={handleAddLessonType} className="flex flex-wrap items-end gap-2">
+              <div className="min-w-[12rem] flex-1">
+                <label htmlFor="new-lesson-type" className="mb-1 block text-xs text-slate-400">
+                  追加
+                </label>
+                <input
+                  id="new-lesson-type"
+                  value={newLessonTypeName}
+                  onChange={(e) => setNewLessonTypeName(e.target.value)}
+                  placeholder="例: 通常"
+                  maxLength={100}
+                  className="w-full rounded-lg border border-slate-700 bg-slate-800/80 px-3 py-2 text-slate-100 placeholder:text-slate-500 focus:border-cyan-500/60 focus:outline-none focus:ring-2 focus:ring-cyan-500/25"
+                />
+              </div>
+              <button
+                type="submit"
+                className="rounded-lg bg-cyan-600 px-4 py-2 text-sm font-semibold text-white hover:bg-cyan-500"
+              >
+                追加
+              </button>
+            </form>
+            <ul className="mt-4 space-y-2">
+              {lessonTypes.map((row) => (
+                <li
+                  key={row.id}
+                  className="flex flex-col gap-2 rounded-xl border border-slate-800 bg-slate-950/60 p-3 sm:flex-row sm:items-center"
+                >
+                  <input
+                    aria-label={`授業種別 ${row.name}`}
+                    value={draftNames[row.id] ?? row.name}
+                    onChange={(e) => setDraftNames((prev) => ({ ...prev, [row.id]: e.target.value }))}
+                    maxLength={100}
+                    className="min-w-0 flex-1 rounded-lg border border-slate-700 bg-slate-800/80 px-3 py-2 text-slate-100"
+                  />
+                  <div className="flex shrink-0 flex-wrap gap-2">
+                    <button
+                      type="button"
+                      className="rounded-lg border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-800"
+                      onClick={() => void patchLessonType(row.id)}
+                    >
+                      更新
+                    </button>
+                    <button
+                      type="button"
+                      className="rounded-lg border border-rose-500/40 bg-rose-950/50 px-3 py-1.5 text-sm text-rose-200 hover:bg-rose-900/60"
+                      onClick={() => void disableLessonType(row.id)}
+                    >
+                      無効化
+                    </button>
+                  </div>
+                </li>
+              ))}
+              {lessonTypes.length === 0 && (
+                <li className="text-sm text-slate-500">授業種別がまだありません。</li>
+              )}
+            </ul>
+          </PresetSection>
+
+          <PresetSection title="時間枠">
+            <form onSubmit={handleAddTimeSlot} className="flex flex-wrap items-end gap-2">
+              <div>
+                <label htmlFor="new-slot-start" className="mb-1 block text-xs text-slate-400">
+                  開始
+                </label>
+                <input
+                  id="new-slot-start"
+                  type="time"
+                  value={newSlotStart}
+                  onChange={(e) => setNewSlotStart(e.target.value)}
+                  className="rounded-lg border border-slate-700 bg-slate-800/80 px-3 py-2 text-slate-100"
+                />
+              </div>
+              <div>
+                <label htmlFor="new-slot-end" className="mb-1 block text-xs text-slate-400">
+                  終了
+                </label>
+                <input
+                  id="new-slot-end"
+                  type="time"
+                  value={newSlotEnd}
+                  onChange={(e) => setNewSlotEnd(e.target.value)}
+                  className="rounded-lg border border-slate-700 bg-slate-800/80 px-3 py-2 text-slate-100"
+                />
+              </div>
+              <button
+                type="submit"
+                className="rounded-lg bg-cyan-600 px-4 py-2 text-sm font-semibold text-white hover:bg-cyan-500"
+              >
+                追加
+              </button>
+            </form>
+            <ul className="mt-4 space-y-2">
+              {timeSlots.map((row) => {
+                const d = draftSlots[row.id] ?? { start: row.startTime, end: row.endTime };
+                return (
+                  <li
+                    key={row.id}
+                    className="flex flex-col gap-2 rounded-xl border border-slate-800 bg-slate-950/60 p-3 sm:flex-row sm:items-end"
+                  >
+                    <div className="flex flex-wrap gap-2">
+                      <div>
+                        <span className="mb-1 block text-xs text-slate-400">開始</span>
+                        <input
+                          type="time"
+                          aria-label={`時間枠開始 ${row.id}`}
+                          value={d.start}
+                          onChange={(e) =>
+                            setDraftSlots((prev) => ({
+                              ...prev,
+                              [row.id]: { ...d, start: e.target.value },
+                            }))
+                          }
+                          className="rounded-lg border border-slate-700 bg-slate-800/80 px-3 py-2 text-slate-100"
+                        />
+                      </div>
+                      <div>
+                        <span className="mb-1 block text-xs text-slate-400">終了</span>
+                        <input
+                          type="time"
+                          aria-label={`時間枠終了 ${row.id}`}
+                          value={d.end}
+                          onChange={(e) =>
+                            setDraftSlots((prev) => ({
+                              ...prev,
+                              [row.id]: { ...d, end: e.target.value },
+                            }))
+                          }
+                          className="rounded-lg border border-slate-700 bg-slate-800/80 px-3 py-2 text-slate-100"
+                        />
+                      </div>
+                    </div>
+                    <div className="flex shrink-0 flex-wrap gap-2 sm:ml-auto">
+                      <button
+                        type="button"
+                        className="rounded-lg border border-slate-600 px-3 py-1.5 text-sm text-slate-200 hover:bg-slate-800"
+                        onClick={() => void patchTimeSlot(row.id)}
+                      >
+                        更新
+                      </button>
+                      <button
+                        type="button"
+                        className="rounded-lg border border-rose-500/40 bg-rose-950/50 px-3 py-1.5 text-sm text-rose-200 hover:bg-rose-900/60"
+                        onClick={() => void disableTimeSlot(row.id)}
+                      >
+                        無効化
+                      </button>
+                    </div>
+                  </li>
+                );
+              })}
+              {timeSlots.length === 0 && (
+                <li className="text-sm text-slate-500">時間枠がまだありません。</li>
+              )}
+            </ul>
+          </PresetSection>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function PresetSection({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="rounded-xl border border-slate-800/80 bg-slate-900/40 p-4 md:p-5">
+      <h3 className="mb-4 text-base font-semibold text-slate-100">{title}</h3>
+      {children}
+    </section>
+  );
+}

--- a/src/components/PresetsSettingsPanel.tsx
+++ b/src/components/PresetsSettingsPanel.tsx
@@ -23,13 +23,9 @@ async function readPresetApiError(
   res: Response,
   options: { fallback: string; invalidRequestHint: string },
 ): Promise<string> {
-  const body = (await res.json().catch(() => ({}))) as { message?: string; detail?: string };
+  const body = (await res.json().catch(() => ({}))) as { message?: string };
   if (body.message === 'invalid request') {
     return options.invalidRequestHint;
-  }
-  const detail = typeof body.detail === 'string' ? body.detail : '';
-  if (detail) {
-    return `${options.fallback}: ${detail}`;
   }
   if (body.message) {
     return `${options.fallback}（${body.message}）`;

--- a/src/components/PresetsSettingsPanel.tsx
+++ b/src/components/PresetsSettingsPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState, type ReactNode } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import type { CurrentUser } from '../types/currentUser';
 
 /** `<input type="time">` の値を API の `HH:mm` に揃える */
@@ -10,6 +10,13 @@ function toHm(v: string): string {
     return `${h}:${m}`;
   }
   return v.trim();
+}
+
+function presetMutationNetworkError(prefix: string, e: unknown): string {
+  if (e instanceof Error) {
+    return `${prefix}: ${e.message}`;
+  }
+  return 'ネットワークエラーが発生しました。';
 }
 
 async function readPresetApiError(
@@ -64,6 +71,12 @@ export default function PresetsSettingsPanel({ currentUser, getAccessTokenSilent
     return isAdmin ? selectedClassroomId : (currentUser.classroomId ?? '');
   }, [currentUser.classroomId, isAdmin, selectedClassroomId]);
 
+  const activeClassroomIdRef = useRef(activeClassroomId);
+  activeClassroomIdRef.current = activeClassroomId;
+
+  const loadPresetsGen = useRef(0);
+  const loadPresetsAbortRef = useRef<AbortController | null>(null);
+
   const authedFetch = useCallback(
     async (path: string, init?: RequestInit) => {
       const token = await getAccessTokenSilently();
@@ -100,20 +113,31 @@ export default function PresetsSettingsPanel({ currentUser, getAccessTokenSilent
   }, [authedFetch, isAdmin]);
 
   const loadPresets = useCallback(async () => {
-    if (!activeClassroomId) {
+    loadPresetsAbortRef.current?.abort();
+    const ac = new AbortController();
+    loadPresetsAbortRef.current = ac;
+    const gen = ++loadPresetsGen.current;
+
+    const classroomAtStart = activeClassroomIdRef.current;
+    if (!classroomAtStart) {
       setSubjects([]);
       setLessonTypes([]);
       setTimeSlots([]);
+      setIsLoadingPresets(false);
       return;
     }
+
     setIsLoadingPresets(true);
     setError(null);
     try {
       const [sRes, lRes, tRes] = await Promise.all([
-        authedFetch(`/api/classrooms/${activeClassroomId}/subjects`),
-        authedFetch(`/api/classrooms/${activeClassroomId}/lesson-types`),
-        authedFetch(`/api/classrooms/${activeClassroomId}/time-slots`),
+        authedFetch(`/api/classrooms/${classroomAtStart}/subjects`, { signal: ac.signal }),
+        authedFetch(`/api/classrooms/${classroomAtStart}/lesson-types`, { signal: ac.signal }),
+        authedFetch(`/api/classrooms/${classroomAtStart}/time-slots`, { signal: ac.signal }),
       ]);
+      if (gen !== loadPresetsGen.current || activeClassroomIdRef.current !== classroomAtStart) {
+        return;
+      }
       if (!sRes.ok || !lRes.ok || !tRes.ok) {
         setError('プリセット一覧の取得に失敗しました。');
         return;
@@ -123,12 +147,17 @@ export default function PresetsSettingsPanel({ currentUser, getAccessTokenSilent
       setTimeSlots((await tRes.json()) as TimeSlotRow[]);
       setDraftNames({});
       setDraftSlots({});
-    } catch {
-      setError('プリセット一覧の取得に失敗しました。');
+    } catch (e) {
+      if (gen !== loadPresetsGen.current || ac.signal.aborted) {
+        return;
+      }
+      setError(presetMutationNetworkError('プリセット一覧の取得に失敗しました', e));
     } finally {
-      setIsLoadingPresets(false);
+      if (gen === loadPresetsGen.current) {
+        setIsLoadingPresets(false);
+      }
     }
-  }, [activeClassroomId, authedFetch]);
+  }, [authedFetch]);
 
   useEffect(() => {
     void loadClassrooms();
@@ -145,22 +174,26 @@ export default function PresetsSettingsPanel({ currentUser, getAccessTokenSilent
       return;
     }
     setError(null);
-    const res = await authedFetch('/api/subjects', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ name, classroomId: activeClassroomId }),
-    });
-    if (!res.ok) {
-      setError(
-        await readPresetApiError(res, {
-          fallback: '科目の追加に失敗しました',
-          invalidRequestHint: '入力内容を確認してください。',
-        }),
-      );
-      return;
+    try {
+      const res = await authedFetch('/api/subjects', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name, classroomId: activeClassroomId }),
+      });
+      if (!res.ok) {
+        setError(
+          await readPresetApiError(res, {
+            fallback: '科目の追加に失敗しました',
+            invalidRequestHint: '入力内容を確認してください。',
+          }),
+        );
+        return;
+      }
+      setNewSubjectName('');
+      await loadPresets();
+    } catch (e) {
+      setError(presetMutationNetworkError('科目の追加に失敗しました', e));
     }
-    setNewSubjectName('');
-    await loadPresets();
   };
 
   const handleAddLessonType = async (e: React.FormEvent) => {
@@ -170,22 +203,26 @@ export default function PresetsSettingsPanel({ currentUser, getAccessTokenSilent
       return;
     }
     setError(null);
-    const res = await authedFetch('/api/lesson-types', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ name, classroomId: activeClassroomId }),
-    });
-    if (!res.ok) {
-      setError(
-        await readPresetApiError(res, {
-          fallback: '授業種別の追加に失敗しました',
-          invalidRequestHint: '入力内容を確認してください。',
-        }),
-      );
-      return;
+    try {
+      const res = await authedFetch('/api/lesson-types', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name, classroomId: activeClassroomId }),
+      });
+      if (!res.ok) {
+        setError(
+          await readPresetApiError(res, {
+            fallback: '授業種別の追加に失敗しました',
+            invalidRequestHint: '入力内容を確認してください。',
+          }),
+        );
+        return;
+      }
+      setNewLessonTypeName('');
+      await loadPresets();
+    } catch (e) {
+      setError(presetMutationNetworkError('授業種別の追加に失敗しました', e));
     }
-    setNewLessonTypeName('');
-    await loadPresets();
   };
 
   const handleAddTimeSlot = async (e: React.FormEvent) => {
@@ -194,25 +231,29 @@ export default function PresetsSettingsPanel({ currentUser, getAccessTokenSilent
       return;
     }
     setError(null);
-    const res = await authedFetch('/api/time-slots', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        classroomId: activeClassroomId,
-        startTime: toHm(newSlotStart),
-        endTime: toHm(newSlotEnd),
-      }),
-    });
-    if (!res.ok) {
-      setError(
-        await readPresetApiError(res, {
-          fallback: '時間枠の追加に失敗しました',
-          invalidRequestHint: '時間枠の入力を確認してください。',
+    try {
+      const res = await authedFetch('/api/time-slots', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          classroomId: activeClassroomId,
+          startTime: toHm(newSlotStart),
+          endTime: toHm(newSlotEnd),
         }),
-      );
-      return;
+      });
+      if (!res.ok) {
+        setError(
+          await readPresetApiError(res, {
+            fallback: '時間枠の追加に失敗しました',
+            invalidRequestHint: '時間枠の入力を確認してください。',
+          }),
+        );
+        return;
+      }
+      await loadPresets();
+    } catch (e) {
+      setError(presetMutationNetworkError('時間枠の追加に失敗しました', e));
     }
-    await loadPresets();
   };
 
   const patchSubject = async (id: string) => {
@@ -221,16 +262,25 @@ export default function PresetsSettingsPanel({ currentUser, getAccessTokenSilent
       return;
     }
     setError(null);
-    const res = await authedFetch(`/api/subjects/${id}`, {
-      method: 'PATCH',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ name }),
-    });
-    if (!res.ok) {
-      setError('科目の更新に失敗しました。');
-      return;
+    try {
+      const res = await authedFetch(`/api/subjects/${id}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+      if (!res.ok) {
+        setError(
+          await readPresetApiError(res, {
+            fallback: '科目の更新に失敗しました',
+            invalidRequestHint: '入力内容を確認してください。',
+          }),
+        );
+        return;
+      }
+      await loadPresets();
+    } catch (e) {
+      setError(presetMutationNetworkError('科目の更新に失敗しました', e));
     }
-    await loadPresets();
   };
 
   const patchLessonType = async (id: string) => {
@@ -239,16 +289,25 @@ export default function PresetsSettingsPanel({ currentUser, getAccessTokenSilent
       return;
     }
     setError(null);
-    const res = await authedFetch(`/api/lesson-types/${id}`, {
-      method: 'PATCH',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ name }),
-    });
-    if (!res.ok) {
-      setError('授業種別の更新に失敗しました。');
-      return;
+    try {
+      const res = await authedFetch(`/api/lesson-types/${id}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+      if (!res.ok) {
+        setError(
+          await readPresetApiError(res, {
+            fallback: '授業種別の更新に失敗しました',
+            invalidRequestHint: '入力内容を確認してください。',
+          }),
+        );
+        return;
+      }
+      await loadPresets();
+    } catch (e) {
+      setError(presetMutationNetworkError('授業種別の更新に失敗しました', e));
     }
-    await loadPresets();
   };
 
   const patchTimeSlot = async (id: string) => {
@@ -257,46 +316,82 @@ export default function PresetsSettingsPanel({ currentUser, getAccessTokenSilent
       return;
     }
     setError(null);
-    const res = await authedFetch(`/api/time-slots/${id}`, {
-      method: 'PATCH',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ startTime: toHm(d.start), endTime: toHm(d.end) }),
-    });
-    if (!res.ok) {
-      setError('時間枠の更新に失敗しました。');
-      return;
+    try {
+      const res = await authedFetch(`/api/time-slots/${id}`, {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ startTime: toHm(d.start), endTime: toHm(d.end) }),
+      });
+      if (!res.ok) {
+        setError(
+          await readPresetApiError(res, {
+            fallback: '時間枠の更新に失敗しました',
+            invalidRequestHint: '時間枠の入力を確認してください。',
+          }),
+        );
+        return;
+      }
+      await loadPresets();
+    } catch (e) {
+      setError(presetMutationNetworkError('時間枠の更新に失敗しました', e));
     }
-    await loadPresets();
   };
 
   const disableSubject = async (id: string) => {
     setError(null);
-    const res = await authedFetch(`/api/subjects/${id}`, { method: 'DELETE' });
-    if (!res.ok) {
-      setError('科目の無効化に失敗しました。');
-      return;
+    try {
+      const res = await authedFetch(`/api/subjects/${id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        setError(
+          await readPresetApiError(res, {
+            fallback: '科目の無効化に失敗しました',
+            invalidRequestHint: '入力内容を確認してください。',
+          }),
+        );
+        return;
+      }
+      await loadPresets();
+    } catch (e) {
+      setError(presetMutationNetworkError('科目の無効化に失敗しました', e));
     }
-    await loadPresets();
   };
 
   const disableLessonType = async (id: string) => {
     setError(null);
-    const res = await authedFetch(`/api/lesson-types/${id}`, { method: 'DELETE' });
-    if (!res.ok) {
-      setError('授業種別の無効化に失敗しました。');
-      return;
+    try {
+      const res = await authedFetch(`/api/lesson-types/${id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        setError(
+          await readPresetApiError(res, {
+            fallback: '授業種別の無効化に失敗しました',
+            invalidRequestHint: '入力内容を確認してください。',
+          }),
+        );
+        return;
+      }
+      await loadPresets();
+    } catch (e) {
+      setError(presetMutationNetworkError('授業種別の無効化に失敗しました', e));
     }
-    await loadPresets();
   };
 
   const disableTimeSlot = async (id: string) => {
     setError(null);
-    const res = await authedFetch(`/api/time-slots/${id}`, { method: 'DELETE' });
-    if (!res.ok) {
-      setError('時間枠の無効化に失敗しました。');
-      return;
+    try {
+      const res = await authedFetch(`/api/time-slots/${id}`, { method: 'DELETE' });
+      if (!res.ok) {
+        setError(
+          await readPresetApiError(res, {
+            fallback: '時間枠の無効化に失敗しました',
+            invalidRequestHint: '時間枠の入力を確認してください。',
+          }),
+        );
+        return;
+      }
+      await loadPresets();
+    } catch (e) {
+      setError(presetMutationNetworkError('時間枠の無効化に失敗しました', e));
     }
-    await loadPresets();
   };
 
   if (!isAdmin && !currentUser.classroomId) {

--- a/src/components/StudentManagementPanel.tsx
+++ b/src/components/StudentManagementPanel.tsx
@@ -191,14 +191,18 @@ export default function StudentManagementPanel({ currentUser, getAccessTokenSile
       return;
     }
     setError(null);
+    const birthYear =
+      typeof values.birthYear === 'number' && Number.isFinite(values.birthYear)
+        ? Math.trunc(values.birthYear)
+        : currentYear - 10;
     try {
       const response = await authedFetch('/api/students', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({
-          name: values.name,
-          email: values.email,
-          birthYear: values.birthYear,
+          name: values.name.trim(),
+          email: values.email.trim(),
+          birthYear,
           classroomId,
         }),
       });
@@ -209,8 +213,22 @@ export default function StudentManagementPanel({ currentUser, getAccessTokenSile
         } else if (response.status === 404) {
           setError('教室が見つかりません。');
         } else {
-          const body = (await response.json().catch(() => ({}))) as { message?: string };
-          setError(body.message === 'invalid request' ? '入力内容を確認してください。' : '生徒の登録に失敗しました。');
+          const body = (await response.json().catch(() => ({}))) as { message?: string; detail?: string };
+          const msg = body.message;
+          const detail = typeof body.detail === 'string' ? body.detail : '';
+          if (msg === 'invalid request') {
+            setError('入力内容を確認してください。');
+          } else if (msg === 'failed to create student') {
+            setError(
+              detail
+                ? `データベースへの保存に失敗しました: ${detail}`
+                : 'データベースへの保存に失敗しました。ローカル D1 のマイグレーションがすべて適用されているか確認してください。',
+            );
+          } else if (msg) {
+            setError(detail ? `生徒の登録に失敗しました: ${msg}（${detail}）` : `生徒の登録に失敗しました: ${msg}`);
+          } else {
+            setError(detail ? `生徒の登録に失敗しました: ${detail}` : '生徒の登録に失敗しました。');
+          }
         }
         return;
       }

--- a/src/components/StudentManagementPanel.tsx
+++ b/src/components/StudentManagementPanel.tsx
@@ -213,21 +213,18 @@ export default function StudentManagementPanel({ currentUser, getAccessTokenSile
         } else if (response.status === 404) {
           setError('教室が見つかりません。');
         } else {
-          const body = (await response.json().catch(() => ({}))) as { message?: string; detail?: string };
+          const body = (await response.json().catch(() => ({}))) as { message?: string };
           const msg = body.message;
-          const detail = typeof body.detail === 'string' ? body.detail : '';
           if (msg === 'invalid request') {
             setError('入力内容を確認してください。');
           } else if (msg === 'failed to create student') {
             setError(
-              detail
-                ? `データベースへの保存に失敗しました: ${detail}`
-                : 'データベースへの保存に失敗しました。ローカル D1 のマイグレーションがすべて適用されているか確認してください。',
+              'データベースへの保存に失敗しました。ローカル D1 のマイグレーションがすべて適用されているか確認してください。',
             );
           } else if (msg) {
-            setError(detail ? `生徒の登録に失敗しました: ${msg}（${detail}）` : `生徒の登録に失敗しました: ${msg}`);
+            setError(`生徒の登録に失敗しました: ${msg}`);
           } else {
-            setError(detail ? `生徒の登録に失敗しました: ${detail}` : '生徒の登録に失敗しました。');
+            setError('生徒の登録に失敗しました。');
           }
         }
         return;

--- a/src/pages/PresetsSettingsPage.tsx
+++ b/src/pages/PresetsSettingsPage.tsx
@@ -16,7 +16,7 @@ export default function PresetsSettingsPage({
     return <p className="text-sm text-slate-300">ユーザー情報を読み込み中...</p>;
   }
 
-  if (!currentUser || currentUser.role === 'staff') {
+  if (!currentUser || (currentUser.role !== 'admin' && currentUser.role !== 'manager')) {
     return <p className="text-sm text-slate-300">教室長以上が授業プリセット設定を利用できます。</p>;
   }
 

--- a/src/pages/PresetsSettingsPage.tsx
+++ b/src/pages/PresetsSettingsPage.tsx
@@ -1,0 +1,29 @@
+import PresetsSettingsPanel from '../components/PresetsSettingsPanel';
+import type { CurrentUser } from '../types/currentUser';
+
+type Props = {
+  currentUser: CurrentUser | null;
+  isLoadingCurrentUser: boolean;
+  getAccessTokenSilently: () => Promise<string>;
+};
+
+export default function PresetsSettingsPage({
+  currentUser,
+  isLoadingCurrentUser,
+  getAccessTokenSilently,
+}: Props) {
+  if (isLoadingCurrentUser) {
+    return <p className="text-sm text-slate-300">ユーザー情報を読み込み中...</p>;
+  }
+
+  if (!currentUser || currentUser.role === 'staff') {
+    return <p className="text-sm text-slate-300">教室長以上が授業プリセット設定を利用できます。</p>;
+  }
+
+  return (
+    <PresetsSettingsPanel
+      currentUser={currentUser}
+      getAccessTokenSilently={getAccessTokenSilently}
+    />
+  );
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Presets Settings page and nav link to manage subjects, lesson types, and time slots per classroom (create/edit/soft-delete), role-aware.
  * New API endpoints to list/create/patch/delete presets per classroom.

* **Improvements**
  * Stronger time parsing/normalization (HH:mm) and validation: endTime must be after startTime; partial updates supported.
  * Student creation payload normalization and clearer error responses; API now maps missing classroom to 404 and logs certain server errors.

* **Bug Fixes**
  * Classroom deletion atomically soft-deletes related presets and restores them on rollback.

* **Tests**
  * New comprehensive API tests covering presets, authorization, validation, transactional flows, and updated student-insert error expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->