### PR TITLE
feat: add button for move to student calendar

### DIFF
--- a/src/components/StudentManagementPanel.tsx
+++ b/src/components/StudentManagementPanel.tsx
@@ -521,6 +521,16 @@ export default function StudentManagementPanel({
                       type="button"
                       variant="outline"
                       size="sm"
+                      asChild
+                    >
+                      <a href={`/share/calendar?student_id=${encodeURIComponent(row.id)}`}>
+                        生徒カレンダーへ
+                      </a>
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="secondary"
+                      size="sm"
                       onClick={() => void handleCopyShareLink(row.id)}
                     >
                       {copiedShareStudentId === row.id


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a calendar sharing button to student list rows.
  - Users can open each student’s calendar share page directly from the student management panel.
- **Existing Functionality**
  - The option to copy a student’s sharing link remains available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->